### PR TITLE
feat: integração frontend-backend e fluxo multiplayer

### DIFF
--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,62 @@
+# Estratégia de Desenvolvimento — Archeos Society
+
+## Equipe
+
+| Membro | Papel |
+|--------|-------|
+| A | Tech Lead / DevOps — branches, PRs, CI, integração |
+| B | Frontend — Lobby, Setup, SeasonEnd, GameEnd |
+| C | Frontend — Game screen, mecânica de macaco, Expedition |
+| D | Backend — Criação de partida e turno (RF01–RF20) |
+| E | Backend — Expedição e fim de temporada (RF21–RF39) |
+| F | Backend + Integração — Pontuação, vencedor, testes (RF37–RF42) |
+
+---
+
+## Estratégia de Ramificação
+
+```
+main          ← produção / entregas estáveis
+└── develop   ← integração (toda feature converge aqui antes de ir para main)
+    ├── feature/lobby-setup
+    ├── feature/game-screen
+    ├── feature/expedition-screen
+    ├── feature/season-game-end
+    ├── feature/backend-game-setup
+    ├── feature/backend-turn
+    ├── feature/backend-expedition
+    ├── feature/backend-scoring
+    └── ci/github-actions
+```
+
+**Regras:**
+- Nenhum commit direto em `main` ou `develop`
+- Toda branch parte de `develop` e volta via **Pull Request com ao menos 1 aprovação**
+- Nome das branches: `feature/<descricao>` ou `fix/<descricao>`
+- Toda PR deve referenciar a Issue do RF correspondente (`Closes #N`)
+
+---
+
+## Cronograma (03/05 – 12/05)
+
+| Data | Entrega |
+|------|---------|
+| **03/05** | Setup do projeto: branch `develop`, Issues no GitHub (RF01–RF42 + RNF01–RNF09), CI configurado |
+| **04/05** | RF01–RF09: criação de partida, baralho, sítios, jogadores, temporadas (backend + Lobby/Setup frontend) |
+| **05/05** | RF10–RF16: ordem de turno, compra de cartas, limite de mão |
+| **06/05** | RF17–RF24: mecânica de macaco, início da validação de expedição |
+| **07/05** | RF25–RF33: expedição completa, efeitos de papéis, sítios arqueológicos |
+| **08/05** | RF34–RF42: fim de temporada, pontuação, vencedor, desempate |
+| **09/05** | Integração geral: conectar frontend ↔ backend |
+| **10/05** | Testes de cenários borda, polimento, monitoramento (EV/PV) |
+| **11/05** | Ensaio da demo, preparação dos slides |
+| **12/05** | Apresentação |
+
+---
+
+## Controle de Modificações
+
+- **Issues no GitHub**: uma por RF/RNF — rastreiam o que foi pedido e quando foi entregue
+- **Pull Requests**: vinculam código às Issues com `Closes #N`; exigem aprovação antes do merge
+- **GitHub Actions**: CI roda build do frontend + testes do backend a cada push em `develop` e `main`
+- **EV/PV por membro**: medido por Issues fechadas e commits por autor (`git shortlog -sn`)

--- a/frontend/src/api/adapters.ts
+++ b/frontend/src/api/adapters.ts
@@ -1,0 +1,80 @@
+import { CardColor, CardFunction, GameCard, Player } from '../app/types'
+import { BackendCard, BackendGameState, BackendPlayer } from './types'
+
+const REGION_TO_COLOR: Record<string, CardColor> = {
+  'América do Norte': 'red',
+  'América do Sul': 'green',
+  'Europa': 'blue',
+  'África': 'yellow',
+  'Ásia': 'purple',
+  'Oceania': 'red',
+  'Especial': 'red',
+}
+
+const ROLE_TO_FUNCTION: Record<string, CardFunction> = {
+  'Botânico': 'research',
+  'Linguista': 'research',
+  'Professor': 'research',
+  'Explorador': 'transport',
+  'Guia': 'excavation',
+  'Médico': 'funding',
+  'Mercenário': 'artifact',
+  'Cartógrafo': 'excavation',
+  'Piloto': 'transport',
+  'Patrono': 'funding',
+  'Curador': 'artifact',
+  'Fotógrafo': 'artifact',
+  'Estudante': 'excavation',
+  'Macaco': 'monkey',
+}
+
+const PLAYER_COLORS = ['#ef4444', '#3b82f6', '#22c55e', '#eab308', '#a855f7', '#f97316']
+
+export function adaptCard(card: BackendCard, index: number): GameCard {
+  return {
+    id: `card-${index}-${card.role}-${card.color}`,
+    color: REGION_TO_COLOR[card.color] ?? 'red',
+    function: card.is_monkey ? 'monkey' : (ROLE_TO_FUNCTION[card.role] ?? 'excavation'),
+    value: 1,
+    role: card.role,
+    region: card.color,
+  }
+}
+
+export function adaptPlayer(
+  playerId: string,
+  backendPlayer: BackendPlayer,
+  displayColor: string,
+): Player {
+  return {
+    id: playerId,
+    name: playerId,
+    color: displayColor,
+    score: backendPlayer.score,
+    cards: backendPlayer.hand.map((c, i) => adaptCard(c, i)),
+    position: Math.max(0, ...Object.values(backendPlayer.tracks)),
+    tracks: backendPlayer.tracks,
+  }
+}
+
+export function adaptGameState(
+  state: BackendGameState,
+  playerColors: Record<string, string>,
+) {
+  const players = state.player_order.map((pid, i) => {
+    const bp = state.players[pid]
+    const color = playerColors[pid] ?? PLAYER_COLORS[i % PLAYER_COLORS.length]
+    return adaptPlayer(pid, bp, color)
+  })
+
+  const market = state.market.map((c, i) => adaptCard(c, i))
+
+  return {
+    players,
+    market,
+    currentPlayerId: state.current_turn_player_id,
+    season: state.season,
+    monkeysFound: state.monkeys_found,
+    status: state.status,
+  }
+}

--- a/frontend/src/api/game.ts
+++ b/frontend/src/api/game.ts
@@ -1,24 +1,32 @@
 import api from './client'
 
 export const gameApi = {
-  createGame: (payload: { players: { name: string; role: string }[]; sites: string[] }) =>
-    api.post('/game/create', payload),
+  createGame: (payload: {
+    player_ids: string[]
+    selected_roles?: string[]
+    site_configs?: Record<string, 'A' | 'B'>
+  }) => api.post('/game/create', payload),
 
-  getState: (gameId: string) =>
-    api.get(`/game/${gameId}`),
+  getState: (gameId: string) => api.get(`/game/${gameId}`),
 
-  buyFromMarket: (gameId: string, cardId: string) =>
-    api.post(`/game/${gameId}/buy-market`, { card_id: cardId }),
+  getSummary: (gameId: string) => api.get(`/game/${gameId}/summary`),
 
-  buyFromDeck: (gameId: string) =>
-    api.post(`/game/${gameId}/buy-deck`),
+  drawFromMarket: (gameId: string, playerId: string, marketIndex: number) =>
+    api.post(`/game/${gameId}/draw/market`, { player_id: playerId, market_index: marketIndex }),
 
-  playExpedition: (gameId: string, cardIds: string[], leaderId: string) =>
-    api.post(`/game/${gameId}/expedition`, { card_ids: cardIds, leader_id: leaderId }),
+  drawFromDeck: (gameId: string, playerId: string) =>
+    api.post(`/game/${gameId}/draw/deck`, { player_id: playerId }),
 
-  endTurn: (gameId: string) =>
-    api.post(`/game/${gameId}/end-turn`),
+  playExpedition: (
+    gameId: string,
+    payload: {
+      player_id: string
+      card_indices: number[]
+      leader_index: number
+      target_track?: string
+      choose_to_score?: boolean
+    },
+  ) => api.post(`/game/${gameId}/play-expedition`, payload),
 
-  endSeason: (gameId: string) =>
-    api.post(`/game/${gameId}/end-season`),
+  nextSeason: (gameId: string) => api.post(`/game/${gameId}/ready`),
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,0 +1,47 @@
+export interface BackendCard {
+  role: string
+  color: string
+  is_monkey: boolean
+}
+
+export interface BackendExpedition {
+  cards: BackendCard[]
+  leader: BackendCard
+  color_matched: boolean
+}
+
+export interface BackendPlayer {
+  id: string
+  color_assigned: string | null
+  score: number
+  hand: BackendCard[]
+  expeditions_played: BackendExpedition[]
+  tracks: Record<string, number>
+  linguist_track: number
+  relics: number
+  professor_tokens: number[]
+  extra_vehicles: Record<string, number>
+  max_expedition?: number
+}
+
+export interface BackendGameState {
+  game_id: string
+  status: 'WAITING_PLAYERS' | 'PLAYING' | 'SEASON_ENDED' | 'FINISHED'
+  players: Record<string, BackendPlayer>
+  player_order: string[]
+  current_turn_index: number
+  current_turn_player_id: string | null
+  deck: BackendCard[]
+  market: BackendCard[]
+  monkeys_found: number
+  season: number
+  max_seasons: number
+  site_configurations: Record<string, 'A' | 'B'>
+}
+
+export interface BackendRankingEntry {
+  player_id: string
+  total_score: number
+  max_expedition: number
+  tracks: Record<string, number>
+}

--- a/frontend/src/app/pages/Expedition.tsx
+++ b/frontend/src/app/pages/Expedition.tsx
@@ -2,292 +2,143 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { Button } from '../components/ui/button';
 import { GameCard } from '../components/GameCard';
-import { Player, GameCard as GameCardType } from '../types';
+import { GameCard as GameCardType } from '../types';
 import { motion } from 'motion/react';
-import { ArrowLeft, CheckCircle, Crown, AlertTriangle } from 'lucide-react';
+import { ArrowLeft, Crown, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Toaster } from '../components/ui/sonner';
+import { gameApi } from '../../api/game';
 
 export default function Expedition() {
   const navigate = useNavigate();
   const location = useLocation();
-  const {
-    players: initialPlayers,
-    currentPlayerIndex,
-    selectedCards: initialSelectedCards,
-    season,
-    market: initialMarket,
-    revealedMonkeys,
-    turnCount
-  } = location.state || {};
-
-  // Redirect if no state data
-  useEffect(() => {
-    if (!initialPlayers || !initialSelectedCards) {
-      navigate('/');
-    }
-  }, [initialPlayers, initialSelectedCards, navigate]);
-
-  const [players] = useState<Player[]>(initialPlayers || []);
-  const [market] = useState<GameCardType[]>(initialMarket || []);
-  const currentPlayer = players[currentPlayerIndex];
-  
-  // Guard clause
-  if (!currentPlayer || !initialSelectedCards) {
-    return null;
+  const state = (location.state ?? {}) as {
+    gameId?: string
+    playerId?: string
+    selectedIndices?: number[]
+    selectedCards?: GameCardType[]
   }
-  
-  const selectedCardObjects = currentPlayer.cards.filter(
-    card => initialSelectedCards.includes(card.id)
-  );
-  
-  const [leader, setLeader] = useState<GameCardType | null>(null);
-  const [validationError, setValidationError] = useState<string>('');
+  const { gameId, playerId, selectedIndices, selectedCards } = state
 
-  const validateExpedition = (): boolean => {
-    if (!leader) {
-      setValidationError('Selecione uma carta líder!');
-      return false;
+  const [leaderPos, setLeaderPos] = useState<number | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!gameId || !playerId || !selectedCards?.length) navigate('/')
+  }, [gameId, playerId, selectedCards, navigate])
+
+  if (!gameId || !playerId || !selectedCards?.length) return null
+
+  const leaderCard = leaderPos !== null ? selectedCards[leaderPos] : null
+
+  const isValidMember = (card: GameCardType) => {
+    if (!leaderCard || card === leaderCard) return true
+    return card.region === leaderCard.region || card.role === leaderCard.role
+  }
+
+  const allValid = leaderPos !== null && selectedCards.every((c: GameCardType, i: number) =>
+    i === leaderPos || isValidMember(c)
+  )
+
+  const submitExpedition = async () => {
+    if (leaderPos === null) { toast.error('Escolha o líder da expedição!'); return }
+    if (!allValid) { toast.error('Algumas cartas não são compatíveis com o líder!'); return }
+
+    setLoading(true)
+    try {
+      await gameApi.playExpedition(gameId, {
+        player_id: playerId,
+        card_indices: selectedIndices ?? [],
+        leader_index: leaderPos,
+      })
+      toast.success('Expedição realizada!')
+      navigate('/game', { state: { gameCode: gameId } })
+    } catch (err: any) {
+      toast.error(err?.response?.data?.detail ?? 'Erro ao jogar expedição')
+    } finally {
+      setLoading(false)
     }
-
-    if (selectedCardObjects.length < 2) {
-      setValidationError('Expedição precisa de pelo menos 2 cartas!');
-      return false;
-    }
-
-    // Check if all cards have same color OR same function
-    const allSameColor = selectedCardObjects.every(card => card.color === leader.color);
-    const allSameFunction = selectedCardObjects.every(card => card.function === leader.function);
-
-    if (!allSameColor && !allSameFunction) {
-      setValidationError('Todas as cartas devem ter a mesma cor OU a mesma função!');
-      return false;
-    }
-
-    setValidationError('');
-    return true;
-  };
-
-  const confirmExpedition = () => {
-    if (!validateExpedition()) {
-      toast.error(validationError);
-      return;
-    }
-
-    // Calculate points
-    const points = selectedCardObjects.reduce((sum, card) => sum + card.value, 0);
-    const bonus = leader ? Math.floor(leader.value * 1.5) : 0;
-    const totalPoints = points + bonus;
-
-    // Update player
-    const updatedPlayers = [...players];
-    updatedPlayers[currentPlayerIndex].score += totalPoints;
-    updatedPlayers[currentPlayerIndex].position = Math.min(
-      updatedPlayers[currentPlayerIndex].position + 1,
-      10
-    );
-
-    // Get remaining cards from hand that were NOT selected for the expedition
-    // These cards should be available to other players
-    const cardsNotUsedInExpedition = updatedPlayers[currentPlayerIndex].cards.filter(
-      card => !initialSelectedCards.includes(card.id)
-    );
-
-    // Remove ALL cards from player's hand (both selected and not selected)
-    // Cards used in expedition are discarded
-    // Cards not used go to the market
-    updatedPlayers[currentPlayerIndex].cards = [];
-
-    // Add cards that were not used in expedition to market for other players
-    const updatedMarket = [...market, ...cardsNotUsedInExpedition];
-
-    // Move to next player
-    const nextPlayerIndex = (currentPlayerIndex + 1) % updatedPlayers.length;
-
-    toast.success(`Expedição concluída! +${totalPoints} pontos`);
-
-    setTimeout(() => {
-      navigate('/game', {
-        state: {
-          players: updatedPlayers,
-          season,
-          market: updatedMarket,
-          currentPlayerIndex: nextPlayerIndex,
-          revealedMonkeys,
-          turnCount: turnCount + 1
-        }
-      });
-    }, 1000);
-  };
-
-  const cancel = () => {
-    navigate('/game', {
-      state: {
-        players,
-        season,
-        market,
-        currentPlayerIndex,
-        revealedMonkeys,
-        turnCount
-      }
-    });
-  };
-
-  const selectLeader = (card: GameCardType) => {
-    setLeader(card);
-    setValidationError('');
-  };
-
-  // Check validation in real-time
-  const getValidationStatus = () => {
-    if (!leader) return { valid: false, message: 'Selecione uma carta líder' };
-    
-    const allSameColor = selectedCardObjects.every(card => card.color === leader.color);
-    const allSameFunction = selectedCardObjects.every(card => card.function === leader.function);
-
-    if (allSameColor) {
-      return { valid: true, message: `✓ Todas as cartas são da cor ${leader.color}` };
-    }
-    if (allSameFunction) {
-      return { valid: true, message: `✓ Todas as cartas têm a função ${leader.function}` };
-    }
-    
-    return { valid: false, message: '✗ Cartas devem ter mesma cor OU mesma função' };
-  };
-
-  const validation = getValidationStatus();
-  const totalPoints = selectedCardObjects.reduce((sum, card) => sum + card.value, 0);
-  const leaderBonus = leader ? Math.floor(leader.value * 1.5) : 0;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-4 overflow-y-auto">
       <Toaster position="top-center" />
-      
-      <div className="max-w-4xl mx-auto py-8">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-        >
-          {/* Header */}
-          <div className="mb-8">
-            <Button
-              variant="ghost"
-              onClick={cancel}
-              className="mb-4 text-slate-400 hover:text-white"
-            >
-              <ArrowLeft className="w-4 h-4 mr-2" />
-              Voltar
-            </Button>
-            
-            <h1 className="text-3xl md:text-5xl font-bold text-white mb-2">
-              Iniciar Expedição
-            </h1>
-            <p className="text-slate-400">
-              Escolha a carta líder e valide sua expedição
-            </p>
-          </div>
-
-          {/* Current Player */}
-          <div 
-            className="bg-slate-800/50 backdrop-blur-xl rounded-lg p-4 mb-6 flex items-center gap-3"
+      <div className="max-w-3xl mx-auto py-8">
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+          <button
+            onClick={() => navigate(-1)}
+            className="text-slate-400 hover:text-white text-sm mb-6 flex items-center gap-1"
           >
-            <div 
-              className="w-12 h-12 rounded-full flex-shrink-0"
-              style={{ backgroundColor: currentPlayer.color }}
-            />
-            <div>
-              <div className="text-sm text-slate-400">Jogador</div>
-              <div className="text-xl font-bold text-white">{currentPlayer.name}</div>
-            </div>
-          </div>
+            <ArrowLeft className="w-4 h-4" /> Voltar
+          </button>
 
-          {/* Leader Selection */}
+          <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">Expedição</h1>
+          <p className="text-slate-400 mb-8">
+            Clique em uma carta para torná-la líder. As demais devem compartilhar região ou papel com o líder.
+          </p>
+
           <div className="mb-8">
             <h2 className="text-xl font-bold text-white mb-4 flex items-center gap-2">
-              <Crown className="w-6 h-6 text-amber-500" />
-              Selecione a Carta Líder
+              <Crown className="w-5 h-5 text-amber-400" />
+              Cartas Selecionadas
             </h2>
-            
-            <div className="flex gap-3 overflow-x-auto pb-4">
-              {selectedCardObjects.map((card) => (
-                <div key={card.id} onClick={() => selectLeader(card)}>
-                  <GameCard 
-                    card={card}
-                    selected={leader?.id === card.id}
-                  />
-                </div>
-              ))}
+            <div className="flex flex-wrap gap-4">
+              {selectedCards.map((card: GameCardType, idx: number) => {
+                const isLeader = leaderPos === idx
+                const valid = leaderPos === null || idx === leaderPos || isValidMember(card)
+                return (
+                  <motion.div
+                    key={card.id}
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.95 }}
+                    onClick={() => setLeaderPos(idx)}
+                    className={`relative cursor-pointer rounded-xl ring-2 transition-all ${
+                      isLeader
+                        ? 'ring-amber-400 shadow-lg shadow-amber-500/30'
+                        : valid
+                        ? 'ring-transparent hover:ring-slate-500'
+                        : 'ring-red-500 opacity-60'
+                    }`}
+                  >
+                    <GameCard card={card} />
+                    {isLeader && (
+                      <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-amber-500 rounded-full px-2 py-0.5 text-xs font-bold text-white flex items-center gap-1 whitespace-nowrap">
+                        <Crown className="w-3 h-3" /> Líder
+                      </div>
+                    )}
+                    {leaderPos !== null && !valid && (
+                      <div className="absolute inset-0 bg-red-900/40 rounded-xl flex items-center justify-center">
+                        <span className="text-red-400 text-xs font-bold">Incompatível</span>
+                      </div>
+                    )}
+                  </motion.div>
+                )
+              })}
             </div>
           </div>
 
-          {/* Validation Status */}
-          <div className={`
-            rounded-lg p-4 mb-6 flex items-start gap-3
-            ${validation.valid 
-              ? 'bg-green-500/20 border border-green-500' 
-              : 'bg-amber-500/20 border border-amber-500'
-            }
-          `}>
-            {validation.valid ? (
-              <CheckCircle className="w-6 h-6 text-green-400 flex-shrink-0 mt-0.5" />
-            ) : (
-              <AlertTriangle className="w-6 h-6 text-amber-400 flex-shrink-0 mt-0.5" />
-            )}
-            <div className="flex-1">
-              <h3 className="font-bold text-white mb-1">Validação da Expedição</h3>
-              <p className={validation.valid ? 'text-green-300' : 'text-amber-300'}>
-                {validation.message}
+          {leaderCard && (
+            <div className="bg-slate-800/60 rounded-xl p-4 mb-6 text-sm text-slate-300">
+              <p>
+                Líder: <span className="text-amber-300 font-semibold">{leaderCard.role ?? leaderCard.function}</span>
+                {leaderCard.region && <> da região <span className="text-amber-300 font-semibold">{leaderCard.region}</span></>}
+              </p>
+              <p className="mt-1 text-slate-400 text-xs">
+                As outras cartas devem ter o mesmo papel ou a mesma região.
               </p>
             </div>
-          </div>
+          )}
 
-          {/* Points Summary */}
-          <div className="bg-slate-800/80 backdrop-blur-xl rounded-lg p-6 mb-6">
-            <h3 className="text-lg font-bold text-white mb-4">Resumo de Pontos</h3>
-            
-            <div className="space-y-3">
-              <div className="flex justify-between items-center">
-                <span className="text-slate-400">Total das cartas</span>
-                <span className="text-2xl font-bold text-white">{totalPoints}</span>
-              </div>
-              
-              {leader && (
-                <div className="flex justify-between items-center">
-                  <span className="text-slate-400">Bônus do líder (×1.5)</span>
-                  <span className="text-2xl font-bold text-amber-500">+{leaderBonus}</span>
-                </div>
-              )}
-              
-              <div className="border-t border-slate-700 pt-3 flex justify-between items-center">
-                <span className="text-lg font-bold text-white">Total</span>
-                <span className="text-3xl font-bold text-green-400">
-                  {totalPoints + leaderBonus}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          {/* Action Buttons */}
-          <div className="flex gap-4">
-            <Button
-              variant="outline"
-              onClick={cancel}
-              className="flex-1 bg-slate-700 border-slate-600 hover:bg-slate-600"
-            >
-              Cancelar
-            </Button>
-            
-            <Button
-              onClick={confirmExpedition}
-              disabled={!validation.valid}
-              className="flex-1 bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <CheckCircle className="w-5 h-5 mr-2" />
-              Confirmar Expedição
-            </Button>
-          </div>
+          <Button
+            onClick={submitExpedition}
+            disabled={leaderPos === null || !allValid || loading}
+            className="w-full bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white text-lg py-6 disabled:opacity-50"
+          >
+            {loading ? <Loader2 className="w-5 h-5 mr-2 animate-spin" /> : <Crown className="w-5 h-5 mr-2" />}
+            Confirmar Expedição
+          </Button>
         </motion.div>
       </div>
     </div>
-  );
+  )
 }

--- a/frontend/src/app/pages/Game.tsx
+++ b/frontend/src/app/pages/Game.tsx
@@ -1,177 +1,143 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { Button } from '../components/ui/button';
 import { GameCard } from '../components/GameCard';
 import { PlayerInfo } from '../components/PlayerInfo';
-import { Player, GameCard as GameCardType, CardColor, CardFunction } from '../types';
+import { Player, GameCard as GameCardType } from '../types';
 import { motion, AnimatePresence } from 'motion/react';
-import { ShoppingCart, Package, Send, AlertCircle, Menu, X, Eye, ChevronDown, ChevronUp, Hand } from 'lucide-react';
+import {
+  ShoppingCart, Package, Send, AlertCircle, Menu, X,
+  Eye, ChevronDown, ChevronUp, Hand, Loader2,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import { Toaster } from '../components/ui/sonner';
 import { useGameStore } from '../../store/gameStore';
+import { gameApi } from '../../api/game';
+import { adaptGameState } from '../../api/adapters';
+import { BackendGameState } from '../../api/types';
 
-const monkeyEmojis = {
-  see: '🙈',
-  hear: '🙉',
-  speak: '🙊',
-};
-
-const generateInitialCard = (id: string): GameCardType => {
-  const colors: CardColor[] = ['red', 'blue', 'green', 'yellow', 'purple'];
-  const functions: CardFunction[] = ['excavation', 'transport', 'research', 'funding', 'artifact'];
-  return {
-    id,
-    color: colors[Math.floor(Math.random() * colors.length)],
-    function: functions[Math.floor(Math.random() * functions.length)],
-    value: Math.floor(Math.random() * 5) + 1,
-  };
-};
-
-const generateCard = (id: string, turnCount: number): GameCardType => {
-  const colors: CardColor[] = ['red', 'blue', 'green', 'yellow', 'purple'];
-  const functions: CardFunction[] = ['excavation', 'transport', 'research', 'funding', 'artifact'];
-  const canHaveMonkey = turnCount >= 5;
-  const monkeyChance = canHaveMonkey ? Math.min(0.15, 0.05 + (turnCount - 5) * 0.02) : 0;
-  const isMonkey = Math.random() < monkeyChance;
-
-  if (isMonkey) {
-    const monkeyTypes: Array<'see' | 'hear' | 'speak'> = ['see', 'hear', 'speak'];
-    return { id, color: 'red', function: 'monkey', value: 0, monkeyType: monkeyTypes[Math.floor(Math.random() * monkeyTypes.length)] };
-  }
-
-  return {
-    id,
-    color: colors[Math.floor(Math.random() * colors.length)],
-    function: functions[Math.floor(Math.random() * functions.length)],
-    value: Math.floor(Math.random() * 5) + 1,
-  };
-};
+const POLL_INTERVAL = 3000
 
 export default function Game() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { myPlayerId } = useGameStore();
+  const { gameId: storedGameId, myPlayerId, playerColors } = useGameStore();
 
-  const playersData = location.state?.players || [];
+  const gid = storedGameId ?? location.state?.gameCode ?? null
 
-  useEffect(() => {
-    if (!playersData || playersData.length === 0) navigate('/');
-  }, [playersData, navigate]);
+  const [players, setPlayers] = useState<Player[]>([])
+  const [market, setMarket] = useState<GameCardType[]>([])
+  const [currentPlayerId, setCurrentPlayerId] = useState<string | null>(null)
+  const [season, setSeason] = useState(1)
+  const [monkeysFound, setMonkeysFound] = useState(0)
+  const [status, setStatus] = useState<string>('PLAYING')
+  const [loading, setLoading] = useState(true)
+  const [actionLoading, setActionLoading] = useState(false)
+  const [selectedIndices, setSelectedIndices] = useState<number[]>([])
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const [myHandOpen, setMyHandOpen] = useState(false)
 
-  const initializePlayers = (): Player[] => {
-    if (location.state?.players && location.state.players[0]?.score !== undefined) {
-      return location.state.players;
-    }
-    return playersData.map((p: any, i: number) => ({
-      id: `player-${i}`,
-      name: p.name,
-      color: p.color,
-      score: 0,
-      cards: Array.from({ length: 5 }, (_, j) => generateInitialCard(`${i}-${j}`)),
-      position: 0,
-    }));
-  };
-
-  const [players, setPlayers] = useState<Player[]>(initializePlayers());
-  const [currentPlayerIndex, setCurrentPlayerIndex] = useState(location.state?.currentPlayerIndex || 0);
-  const [market, setMarket] = useState<GameCardType[]>(
-    location.state?.market || Array.from({ length: 5 }, (_, i) => generateInitialCard(`market-${i}`))
-  );
-  const [selectedCards, setSelectedCards] = useState<string[]>([]);
-  const [season, setSeason] = useState(location.state?.season || 1);
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [revealedMonkeys, setRevealedMonkeys] = useState<GameCardType[]>(location.state?.revealedMonkeys || []);
-  const [turnCount, setTurnCount] = useState(location.state?.turnCount || 0);
-  const [myHandOpen, setMyHandOpen] = useState(false);
+  const statusRef = useRef(status)
+  statusRef.current = status
 
   useEffect(() => {
-    if (location.state?.players && location.state.players[0]?.score !== undefined) setPlayers(location.state.players);
-    if (location.state?.market) setMarket(location.state.market);
-    if (location.state?.currentPlayerIndex !== undefined) setCurrentPlayerIndex(location.state.currentPlayerIndex);
-    if (location.state?.revealedMonkeys) setRevealedMonkeys(location.state.revealedMonkeys);
-    if (location.state?.turnCount !== undefined) setTurnCount(location.state.turnCount);
-  }, [location.state]);
+    if (!gid) { navigate('/'); return }
 
-  const currentPlayer = players[currentPlayerIndex];
+    const fetchState = async () => {
+      try {
+        const res = await gameApi.getState(gid)
+        const raw: BackendGameState = res.data
+        const adapted = adaptGameState(raw, playerColors)
+        setPlayers(adapted.players)
+        setMarket(adapted.market)
+        setCurrentPlayerId(adapted.currentPlayerId)
+        setSeason(adapted.season)
+        setMonkeysFound(adapted.monkeysFound)
+        setStatus(adapted.status)
+        setLoading(false)
 
-  // The player bound to this device. Falls back to currentPlayer in single-device mode.
-  const myPlayer = myPlayerId
-    ? (players.find(p => p.id === myPlayerId) ?? currentPlayer)
-    : currentPlayer;
+        if (adapted.status === 'SEASON_ENDED' && statusRef.current !== 'SEASON_ENDED') {
+          navigate('/season-end', { state: { gameId: gid } })
+        } else if (adapted.status === 'FINISHED' && statusRef.current !== 'FINISHED') {
+          navigate('/game-end', { state: { gameId: gid } })
+        }
+      } catch {
+        // silently retry on network errors
+      }
+    }
 
-  const isMyTurn = !myPlayerId || myPlayer?.id === currentPlayer?.id;
+    fetchState()
+    const interval = setInterval(fetchState, POLL_INTERVAL)
+    return () => clearInterval(interval)
+  }, [gid, navigate, playerColors])
 
-  const MAX_HAND_SIZE = 10;
-
+  // Navigate on status change
   useEffect(() => {
-    if (revealedMonkeys.length >= 3) {
-      toast.error('🙈🙉🙊 3 Macacos revelados! Fim da temporada!', { duration: 3000 });
-      setTimeout(() => navigate('/season-end', { state: { players, season, monkeyEnd: true } }), 2000);
+    if (status === 'SEASON_ENDED') navigate('/season-end', { state: { gameId: gid } })
+    else if (status === 'FINISHED') navigate('/game-end', { state: { gameId: gid } })
+  }, [status, gid, navigate])
+
+  if (!gid) return null
+
+  const myPlayer = myPlayerId ? players.find((p) => p.id === myPlayerId) ?? null : null
+  const currentPlayer = players.find((p) => p.id === currentPlayerId) ?? players[0] ?? null
+  const isMyTurn = !!myPlayerId && myPlayerId === currentPlayerId
+
+  const MAX_HAND_SIZE = 10
+  const myCards = myPlayer?.cards ?? []
+  const selectedCards = selectedIndices.map((i) => myCards[i]).filter(Boolean)
+
+  const toggleCardSelection = (index: number) => {
+    const card = myCards[index]
+    if (!card) return
+    if (card.function === 'monkey') { toast.error('Cartas de macaco não podem ser usadas em expedições!'); return }
+    setSelectedIndices((prev) =>
+      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
+    )
+  }
+
+  const buyFromMarket = async (marketIndex: number) => {
+    if (!isMyTurn || !myPlayerId || !gid) return
+    if ((myPlayer?.cards.length ?? 0) >= MAX_HAND_SIZE) { toast.error('Limite de cartas atingido! (máx: 10)'); return }
+    setActionLoading(true)
+    try {
+      await gameApi.drawFromMarket(gid, myPlayerId, marketIndex)
+      toast.success('Carta comprada do mercado!')
+    } catch (err: any) {
+      toast.error(err?.response?.data?.detail ?? 'Erro ao comprar do mercado')
+    } finally {
+      setActionLoading(false)
     }
-  }, [revealedMonkeys, navigate, players, season]);
+  }
 
-  if (!currentPlayer || !myPlayer) return null;
-
-  // ── Actions (only called when isMyTurn is true) ─────────────────────────
-
-  const buyFromMarket = (card: GameCardType) => {
-    if (myPlayer.cards.length >= MAX_HAND_SIZE) { toast.error('Limite de cartas atingido! (máx: 10)'); return; }
-    if (card.function === 'monkey') {
-      setRevealedMonkeys(prev => [...prev, card]);
-      toast.warning(`Macaco revelado! ${monkeyEmojis[card.monkeyType || 'see']} (${revealedMonkeys.length + 1}/3)`, { duration: 2000 });
+  const buyFromDeck = async () => {
+    if (!isMyTurn || !myPlayerId || !gid) return
+    if ((myPlayer?.cards.length ?? 0) >= MAX_HAND_SIZE) { toast.error('Limite de cartas atingido! (máx: 10)'); return }
+    setActionLoading(true)
+    try {
+      await gameApi.drawFromDeck(gid, myPlayerId)
+      toast.success('Carta comprada do baralho!')
+    } catch (err: any) {
+      toast.error(err?.response?.data?.detail ?? 'Erro ao comprar do baralho')
+    } finally {
+      setActionLoading(false)
     }
-    const updated = [...players];
-    updated[currentPlayerIndex].cards.push(card);
-    setPlayers(updated);
-
-    const newMarket = market.filter(c => c.id !== card.id);
-    const newCard = generateCard(`market-${Date.now()}`, turnCount);
-    if (newCard.function === 'monkey') {
-      setTimeout(() => {
-        setRevealedMonkeys(prev => [...prev, newCard]);
-        toast.warning(`Macaco no mercado! ${monkeyEmojis[newCard.monkeyType || 'see']}`, { duration: 2000 });
-      }, 500);
-    }
-    newMarket.push(newCard);
-    setMarket(newMarket);
-    if (card.function !== 'monkey') toast.success('Carta comprada do mercado!');
-    nextTurn();
-  };
-
-  const buyFromDeck = () => {
-    if (myPlayer.cards.length >= MAX_HAND_SIZE) { toast.error('Limite de cartas atingido! (máx: 10)'); return; }
-    const newCard = generateCard(`deck-${Date.now()}`, turnCount);
-    if (newCard.function === 'monkey') {
-      setRevealedMonkeys(prev => [...prev, newCard]);
-      toast.warning(`Macaco comprado! ${monkeyEmojis[newCard.monkeyType || 'see']} (${revealedMonkeys.length + 1}/3)`, { duration: 2000 });
-    }
-    const updated = [...players];
-    updated[currentPlayerIndex].cards.push(newCard);
-    setPlayers(updated);
-    if (newCard.function !== 'monkey') toast.success('Carta comprada do baralho!');
-    nextTurn();
-  };
+  }
 
   const startExpedition = () => {
-    if (selectedCards.length < 2) { toast.error('Selecione ao menos 2 cartas para iniciar uma expedição!'); return; }
-    navigate('/expedition', { state: { players, currentPlayerIndex, selectedCards, season, market, revealedMonkeys, turnCount } });
-  };
+    if (selectedIndices.length < 2) { toast.error('Selecione ao menos 2 cartas!'); return }
+    navigate('/expedition', {
+      state: { gameId: gid, playerId: myPlayerId, selectedIndices, selectedCards },
+    })
+  }
 
-  const toggleCardSelection = (cardId: string) => {
-    const card = myPlayer.cards.find(c => c.id === cardId);
-    if (card?.function === 'monkey') { toast.error('Cartas de macaco não podem ser usadas em expedições!'); return; }
-    setSelectedCards(prev => prev.includes(cardId) ? prev.filter(id => id !== cardId) : [...prev, cardId]);
-  };
-
-  const nextTurn = () => {
-    setSelectedCards([]);
-    const nextIndex = (currentPlayerIndex + 1) % players.length;
-    setCurrentPlayerIndex(nextIndex);
-    setTurnCount(prev => prev + 1);
-    if (nextIndex === 0 && Math.random() > 0.7) navigate('/season-end', { state: { players, season } });
-  };
-
-  // ── Render ───────────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center">
+        <Loader2 className="w-10 h-10 text-amber-400 animate-spin" />
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 overflow-hidden">
@@ -182,20 +148,22 @@ export default function Game() {
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <div>
             <h1 className="text-xl md:text-2xl font-bold text-white">Archeos Society</h1>
-            <p className="text-sm text-slate-400">Temporada {season}</p>
+            <p className="text-sm text-slate-400">Temporada {season} • Macacos: {monkeysFound}/3</p>
           </div>
           <Button variant="ghost" size="icon" className="md:hidden" onClick={() => setMobileMenuOpen(!mobileMenuOpen)}>
             {mobileMenuOpen ? <X /> : <Menu />}
           </Button>
-          <div className="hidden md:block text-right">
-            <div className="text-sm text-slate-400">Vez de</div>
-            <div className="text-lg font-bold" style={{ color: currentPlayer.color }}>{currentPlayer.name}</div>
-          </div>
+          {currentPlayer && (
+            <div className="hidden md:block text-right">
+              <div className="text-sm text-slate-400">Vez de</div>
+              <div className="text-lg font-bold" style={{ color: currentPlayer.color }}>{currentPlayer.name}</div>
+            </div>
+          )}
         </div>
       </div>
 
       {/* Watching banner */}
-      {!isMyTurn && (
+      {!isMyTurn && myPlayerId && (
         <motion.div
           initial={{ opacity: 0, y: -8 }}
           animate={{ opacity: 1, y: 0 }}
@@ -204,8 +172,7 @@ export default function Game() {
           <Eye className="w-4 h-4 text-amber-400 flex-shrink-0" />
           <p className="text-amber-300 text-sm">
             Você está observando — é a vez de{' '}
-            <span className="font-bold" style={{ color: currentPlayer.color }}>{currentPlayer.name}</span>.
-            Suas ações ficam disponíveis quando chegar a sua vez.
+            <span className="font-bold" style={{ color: currentPlayer?.color }}>{currentPlayer?.name}</span>.
           </p>
         </motion.div>
       )}
@@ -213,24 +180,24 @@ export default function Game() {
       <div className="flex flex-col md:flex-row h-[calc(100vh-80px)]">
         {/* Sidebar */}
         <AnimatePresence>
-          {(mobileMenuOpen || window.innerWidth >= 768) && (
+          {(mobileMenuOpen || true) && (
             <motion.div
               initial={{ x: -300 }} animate={{ x: 0 }} exit={{ x: -300 }}
-              className="w-full md:w-80 bg-slate-800/50 backdrop-blur-xl border-r border-slate-700 p-4 overflow-y-auto absolute md:relative z-20 h-full"
+              className="hidden md:block w-80 bg-slate-800/50 backdrop-blur-xl border-r border-slate-700 p-4 overflow-y-auto"
             >
               <h2 className="text-lg font-bold text-white mb-4">Jogadores</h2>
               <div className="space-y-3">
-                {players.map((player, index) => (
-                  <PlayerInfo key={player.id} player={player} isActive={index === currentPlayerIndex} />
+                {players.map((player) => (
+                  <PlayerInfo key={player.id} player={player} isActive={player.id === currentPlayerId} />
                 ))}
               </div>
 
               <div className="mt-6">
-                <h3 className="text-lg font-bold text-white mb-4">Trilhas Arqueológicas</h3>
+                <h3 className="text-lg font-bold text-white mb-4">Trilhas</h3>
                 {players.map((player) => (
                   <div key={player.id} className="mb-4">
-                    <div className="flex items-center gap-2 mb-2">
-                      <div className="w-4 h-4 rounded-full" style={{ backgroundColor: player.color }} />
+                    <div className="flex items-center gap-2 mb-1">
+                      <div className="w-3 h-3 rounded-full" style={{ backgroundColor: player.color }} />
                       <span className="text-sm text-white">{player.name}</span>
                     </div>
                     <div className="flex gap-1">
@@ -244,17 +211,17 @@ export default function Game() {
 
               <div className="mt-6">
                 <h3 className="text-lg font-bold text-white mb-3">Macacos Revelados</h3>
-                <div className={`p-4 rounded-lg ${revealedMonkeys.length >= 3 ? 'bg-red-500/30 border-2 border-red-500' : 'bg-orange-500/20 border border-orange-500'}`}>
-                  <div className="flex items-center justify-center gap-3 mb-3">
-                    {Array.from({ length: 3 }).map((_, i) => (
-                      <div key={i} className={`w-12 h-12 rounded-full flex items-center justify-center text-2xl ${i < revealedMonkeys.length ? 'bg-orange-600' : 'bg-slate-700'}`}>
-                        {i < revealedMonkeys.length && revealedMonkeys[i] ? monkeyEmojis[revealedMonkeys[i].monkeyType || 'see'] : '?'}
+                <div className={`p-4 rounded-lg ${monkeysFound >= 3 ? 'bg-red-500/30 border-2 border-red-500' : 'bg-orange-500/20 border border-orange-500'}`}>
+                  <div className="flex items-center justify-center gap-3 mb-2">
+                    {['🙈', '🙉', '🙊'].map((emoji, i) => (
+                      <div key={i} className={`w-12 h-12 rounded-full flex items-center justify-center text-2xl ${i < monkeysFound ? 'bg-orange-600' : 'bg-slate-700'}`}>
+                        {i < monkeysFound ? emoji : '?'}
                       </div>
                     ))}
                   </div>
-                  <p className="text-center text-sm font-bold text-orange-300">{revealedMonkeys.length}/3 Macacos</p>
-                  {revealedMonkeys.length >= 2 && revealedMonkeys.length < 3 && (
-                    <p className="text-center text-xs text-orange-200 mt-2">⚠️ Próximo macaco encerra a temporada!</p>
+                  <p className="text-center text-sm font-bold text-orange-300">{monkeysFound}/3 Macacos</p>
+                  {monkeysFound >= 2 && monkeysFound < 3 && (
+                    <p className="text-center text-xs text-orange-200 mt-1">⚠️ Próximo macaco encerra a temporada!</p>
                   )}
                 </div>
               </div>
@@ -265,29 +232,29 @@ export default function Game() {
         {/* Main area */}
         <div className="flex-1 overflow-y-auto p-4 md:p-6">
 
-          {/* Market — always visible, only clickable on your turn */}
+          {/* Market */}
           <div className="mb-6">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-xl font-bold text-white flex items-center gap-2">
                 <ShoppingCart className="w-5 h-5 text-blue-400" />
-                Mercado de Cartas
+                Mercado
               </h2>
               <Button
-                onClick={isMyTurn ? buyFromDeck : undefined}
-                disabled={!isMyTurn}
+                onClick={buyFromDeck}
+                disabled={!isMyTurn || actionLoading}
                 variant="outline"
-                className="bg-purple-500/20 border-purple-500 hover:bg-purple-500/30 disabled:opacity-40 disabled:cursor-not-allowed"
+                className="bg-purple-500/20 border-purple-500 hover:bg-purple-500/30 disabled:opacity-40"
               >
-                <Package className="w-4 h-4 mr-2" />
+                {actionLoading ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Package className="w-4 h-4 mr-2" />}
                 Comprar do Baralho
               </Button>
             </div>
             <div className={`flex gap-3 overflow-x-auto pb-4 ${!isMyTurn ? 'opacity-80' : ''}`}>
-              {market.map((card) => (
+              {market.map((card, idx) => (
                 <div
                   key={card.id}
-                  onClick={isMyTurn ? () => buyFromMarket(card) : undefined}
-                  className={!isMyTurn ? 'cursor-default' : 'cursor-pointer'}
+                  onClick={isMyTurn && !actionLoading ? () => buyFromMarket(idx) : undefined}
+                  className={isMyTurn && !actionLoading ? 'cursor-pointer' : 'cursor-default'}
                 >
                   <GameCard card={card} />
                 </div>
@@ -295,69 +262,66 @@ export default function Game() {
             </div>
           </div>
 
-          {/* Hand section */}
+          {/* Hand area */}
           {isMyTurn ? (
-            /* My turn — show my interactive hand */
             <div className="mb-6">
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-xl font-bold text-white">
                   Sua Mão
-                  <span className={`ml-2 text-sm ${myPlayer.cards.length >= MAX_HAND_SIZE ? 'text-red-400' : 'text-slate-400'}`}>
-                    ({myPlayer.cards.length}/{MAX_HAND_SIZE})
+                  <span className={`ml-2 text-sm ${myCards.length >= MAX_HAND_SIZE ? 'text-red-400' : 'text-slate-400'}`}>
+                    ({myCards.length}/{MAX_HAND_SIZE})
                   </span>
                 </h2>
                 <Button
                   onClick={startExpedition}
-                  disabled={selectedCards.length < 2}
+                  disabled={selectedIndices.length < 2}
                   className="bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 disabled:opacity-50"
                 >
                   <Send className="w-4 h-4 mr-2" />
-                  Iniciar Expedição ({selectedCards.length})
+                  Expedição ({selectedIndices.length})
                 </Button>
               </div>
 
-              {myPlayer.cards.length >= MAX_HAND_SIZE && (
+              {myCards.length >= MAX_HAND_SIZE && (
                 <div className="bg-red-500/20 border border-red-500 rounded-lg p-3 mb-4 flex items-center gap-2">
                   <AlertCircle className="w-5 h-5 text-red-400" />
-                  <p className="text-red-300 text-sm">Limite de cartas atingido! Faça uma expedição antes de comprar mais.</p>
+                  <p className="text-red-300 text-sm">Limite atingido! Faça uma expedição antes de comprar mais.</p>
                 </div>
               )}
 
               <div className="flex gap-3 overflow-x-auto pb-4">
-                {myPlayer.cards.map((card) => (
-                  <div key={card.id} onClick={() => toggleCardSelection(card.id)} className="cursor-pointer">
-                    <GameCard card={card} selected={selectedCards.includes(card.id)} />
+                {myCards.map((card, idx) => (
+                  <div key={card.id} onClick={() => toggleCardSelection(idx)} className="cursor-pointer">
+                    <GameCard card={card} selected={selectedIndices.includes(idx)} />
                   </div>
                 ))}
               </div>
             </div>
           ) : (
-            /* Watching — show only card count for the active player, hand hidden */
             <div className="mb-6">
               <div className="flex items-center gap-3 p-4 bg-slate-800/60 rounded-xl border border-slate-700">
                 <Hand className="w-5 h-5 text-slate-400 flex-shrink-0" />
                 <p className="text-slate-400 text-sm">
-                  <span className="font-semibold" style={{ color: currentPlayer.color }}>{currentPlayer.name}</span>
-                  {' '}tem <span className="text-white font-bold">{currentPlayer.cards.length}</span> carta(s) na mão.
+                  <span className="font-semibold" style={{ color: currentPlayer?.color }}>{currentPlayer?.name}</span>
+                  {' '}tem <span className="text-white font-bold">{currentPlayer?.cards.length ?? 0}</span> carta(s) na mão.
                 </p>
               </div>
             </div>
           )}
 
-          {/* My hand (collapsible) — only shown when watching someone else */}
-          {!isMyTurn && myPlayer.id !== currentPlayer.id && (
+          {/* My hand collapsible when watching */}
+          {!isMyTurn && myPlayer && myPlayer.id !== currentPlayerId && (
             <div className="border border-slate-700 rounded-xl overflow-hidden">
               <button
-                onClick={() => setMyHandOpen(o => !o)}
+                onClick={() => setMyHandOpen((o) => !o)}
                 className="w-full flex items-center justify-between p-4 bg-slate-800/60 hover:bg-slate-800 transition-colors text-left"
               >
                 <span className="text-white font-semibold">
                   Minha Mão
-                  <span className="ml-2 text-slate-400 text-sm font-normal">({myPlayer.cards.length}/{MAX_HAND_SIZE})</span>
+                  <span className="ml-2 text-slate-400 text-sm font-normal">({myCards.length}/{MAX_HAND_SIZE})</span>
                 </span>
                 {myHandOpen ? <ChevronUp className="w-4 h-4 text-slate-400" /> : <ChevronDown className="w-4 h-4 text-slate-400" />}
               </button>
-
               <AnimatePresence>
                 {myHandOpen && (
                   <motion.div
@@ -367,15 +331,14 @@ export default function Game() {
                     className="overflow-hidden"
                   >
                     <div className="flex gap-3 overflow-x-auto p-4 bg-slate-900/40">
-                      {myPlayer.cards.length === 0 ? (
-                        <p className="text-slate-500 text-sm">Sua mão está vazia.</p>
-                      ) : (
-                        myPlayer.cards.map((card) => (
+                      {myCards.length === 0
+                        ? <p className="text-slate-500 text-sm">Sua mão está vazia.</p>
+                        : myCards.map((card) => (
                           <div key={card.id} className="cursor-default">
                             <GameCard card={card} />
                           </div>
                         ))
-                      )}
+                      }
                     </div>
                   </motion.div>
                 )}

--- a/frontend/src/app/pages/GameEnd.tsx
+++ b/frontend/src/app/pages/GameEnd.tsx
@@ -1,78 +1,66 @@
+import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { Button } from '../components/ui/button';
-import { Player } from '../types';
 import { motion } from 'motion/react';
-import { Trophy, Crown, Medal, RotateCcw, Home, Sparkles } from 'lucide-react';
+import { Trophy, Crown, Medal, RotateCcw, Home, Sparkles, Loader2 } from 'lucide-react';
 import confetti from 'canvas-confetti';
-import { useEffect } from 'react';
+import { gameApi } from '../../api/game';
+import { useGameStore } from '../../store/gameStore';
+import { BackendRankingEntry } from '../../api/types';
 
 export default function GameEnd() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { players } = location.state || {};
+  const { gameId: storedGameId, playerColors, reset } = useGameStore()
 
-  // Redirect if no state data
+  const gid: string = location.state?.gameId ?? storedGameId ?? ''
+
+  const [ranking, setRanking] = useState<BackendRankingEntry[]>([])
+  const [loading, setLoading] = useState(true)
+
   useEffect(() => {
-    if (!players) {
-      navigate('/');
-      return;
-    }
+    if (!gid) { navigate('/'); return }
+    gameApi.getSummary(gid).then((res) => {
+      const data: BackendRankingEntry[] = res.data.ranking
+      setRanking(data)
+      setLoading(false)
 
-    // Celebration confetti
-    const duration = 3000;
-    const end = Date.now() + duration;
+      const colors = ['#fbbf24', '#f59e0b', '#ef4444', '#3b82f6']
+      const end = Date.now() + 3000
+      ;(function frame() {
+        confetti({ particleCount: 3, angle: 60, spread: 55, origin: { x: 0 }, colors })
+        confetti({ particleCount: 3, angle: 120, spread: 55, origin: { x: 1 }, colors })
+        if (Date.now() < end) requestAnimationFrame(frame)
+      }())
+    }).catch(() => navigate('/'))
+  }, [gid, navigate])
 
-    const colors = ['#fbbf24', '#f59e0b', '#ef4444', '#3b82f6'];
+  const PLAYER_COLORS_FALLBACK = ['#ef4444', '#3b82f6', '#22c55e', '#eab308', '#a855f7', '#f97316']
 
-    (function frame() {
-      confetti({
-        particleCount: 3,
-        angle: 60,
-        spread: 55,
-        origin: { x: 0 },
-        colors: colors
-      });
-      confetti({
-        particleCount: 3,
-        angle: 120,
-        spread: 55,
-        origin: { x: 1 },
-        colors: colors
-      });
-
-      if (Date.now() < end) {
-        requestAnimationFrame(frame);
-      }
-    }());
-  }, [players, navigate]);
-
-  // Guard clause
-  if (!players) {
-    return null;
-  }
-
-  // Sort players by score
-  const sortedPlayers = [...players].sort((a, b) => b.score - a.score);
-  const winner = sortedPlayers[0];
-  const second = sortedPlayers[1];
-  const third = sortedPlayers[2];
-
-  const playAgain = () => {
-    navigate('/');
-  };
+  const getColor = (playerId: string, index: number) =>
+    playerColors[playerId] ?? PLAYER_COLORS_FALLBACK[index % PLAYER_COLORS_FALLBACK.length]
 
   const getMedalIcon = (position: number) => {
-    switch (position) {
-      case 0:
-        return <Crown className="w-8 h-8 text-amber-500" />;
-      case 1:
-        return <Medal className="w-7 h-7 text-slate-400" />;
-      case 2:
-        return <Medal className="w-6 h-6 text-orange-700" />;
-      default:
-        return null;
-    }
-  };
+    if (position === 0) return <Crown className="w-8 h-8 text-amber-500" />
+    if (position === 1) return <Medal className="w-7 h-7 text-slate-400" />
+    if (position === 2) return <Medal className="w-6 h-6 text-orange-700" />
+    return null
+  }
+
+  const playAgain = () => {
+    reset()
+    navigate('/')
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center">
+        <Loader2 className="w-10 h-10 text-amber-400 animate-spin" />
+      </div>
+    )
+  }
+
+  const winner = ranking[0]
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-4 overflow-y-auto">
@@ -91,101 +79,70 @@ export default function GameEnd() {
           >
             <Trophy className="w-24 h-24 text-amber-500" />
           </motion.div>
-          
-          <h1 className="text-4xl md:text-6xl font-bold text-white mb-2">
-            Fim de Jogo!
-          </h1>
+          <h1 className="text-4xl md:text-6xl font-bold text-white mb-2">Fim de Jogo!</h1>
           <p className="text-slate-400 text-lg">A expedição chegou ao fim</p>
         </div>
 
-        {/* Winner Podium */}
-        <motion.div
-          initial={{ y: 50, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{ delay: 0.4 }}
-          className="bg-gradient-to-br from-amber-500 via-yellow-500 to-orange-500 rounded-2xl p-8 mb-8 text-center relative overflow-hidden"
-        >
-          <div className="absolute inset-0 opacity-20">
-            <div className="absolute inset-0" style={{
+        {/* Winner */}
+        {winner && (
+          <motion.div
+            initial={{ y: 50, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ delay: 0.4 }}
+            className="bg-gradient-to-br from-amber-500 via-yellow-500 to-orange-500 rounded-2xl p-8 mb-8 text-center relative overflow-hidden"
+          >
+            <div className="absolute inset-0 opacity-20" style={{
               backgroundImage: `repeating-linear-gradient(45deg, transparent, transparent 20px, rgba(255,255,255,0.1) 20px, rgba(255,255,255,0.1) 40px)`
             }} />
-          </div>
-          
-          <div className="relative">
-            <Sparkles className="w-12 h-12 text-white mx-auto mb-4" />
-            <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
-              🎉 Vencedor! 🎉
-            </h2>
-            
-            <div className="flex items-center justify-center gap-4 mb-4">
-              <div 
-                className="w-16 h-16 md:w-20 md:h-20 rounded-full ring-4 ring-white"
-                style={{ backgroundColor: winner.color }}
-              />
-              <div className="text-left">
-                <h3 className="text-3xl md:text-5xl font-bold text-white">{winner.name}</h3>
-                <p className="text-2xl text-white/90">{winner.score} pontos</p>
+            <div className="relative">
+              <Sparkles className="w-12 h-12 text-white mx-auto mb-4" />
+              <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">🎉 Vencedor! 🎉</h2>
+              <div className="flex items-center justify-center gap-4 mb-4">
+                <div className="w-16 h-16 md:w-20 md:h-20 rounded-full ring-4 ring-white" style={{ backgroundColor: getColor(winner.player_id, 0) }} />
+                <div className="text-left">
+                  <h3 className="text-3xl md:text-5xl font-bold text-white">{winner.player_id}</h3>
+                  <p className="text-2xl text-white/90">{winner.total_score} pontos</p>
+                </div>
               </div>
             </div>
-          </div>
-        </motion.div>
+          </motion.div>
+        )}
 
-        {/* Final Rankings */}
+        {/* Rankings */}
         <div className="bg-slate-800/80 backdrop-blur-xl rounded-2xl p-6 mb-8">
-          <h2 className="text-2xl font-bold text-white mb-6 text-center">
-            Classificação Final
-          </h2>
-          
+          <h2 className="text-2xl font-bold text-white mb-6 text-center">Classificação Final</h2>
           <div className="space-y-4">
-            {sortedPlayers.map((player: Player, index) => (
+            {ranking.map((entry, index) => (
               <motion.div
-                key={player.id}
+                key={entry.player_id}
                 initial={{ x: -50, opacity: 0 }}
                 animate={{ x: 0, opacity: 1 }}
                 transition={{ delay: 0.6 + index * 0.15 }}
                 className={`
                   relative overflow-hidden rounded-xl p-5
-                  ${index === 0 ? 'bg-gradient-to-r from-amber-500/30 to-orange-500/30 ring-2 ring-amber-500' : 
+                  ${index === 0 ? 'bg-gradient-to-r from-amber-500/30 to-orange-500/30 ring-2 ring-amber-500' :
                     index === 1 ? 'bg-slate-700/70 ring-2 ring-slate-500' :
                     index === 2 ? 'bg-slate-700/50 ring-2 ring-orange-700' :
                     'bg-slate-700/30'
                   }
                 `}
               >
-                {index < 3 && (
-                  <div className="absolute top-0 right-0 p-3">
-                    {getMedalIcon(index)}
-                  </div>
-                )}
-                
+                {index < 3 && <div className="absolute top-0 right-0 p-3">{getMedalIcon(index)}</div>}
                 <div className="flex items-center gap-4">
-                  <div className={`
-                    text-3xl font-bold w-12 text-center
-                    ${index === 0 ? 'text-amber-400' :
-                      index === 1 ? 'text-slate-300' :
-                      index === 2 ? 'text-orange-600' :
-                      'text-slate-500'
-                    }
-                  `}>
+                  <div className={`text-3xl font-bold w-12 text-center ${
+                    index === 0 ? 'text-amber-400' : index === 1 ? 'text-slate-300' : index === 2 ? 'text-orange-600' : 'text-slate-500'
+                  }`}>
                     #{index + 1}
                   </div>
-                  
-                  <div 
-                    className="w-14 h-14 rounded-full ring-2 ring-white/50"
-                    style={{ backgroundColor: player.color }}
-                  />
-                  
+                  <div className="w-14 h-14 rounded-full ring-2 ring-white/50" style={{ backgroundColor: getColor(entry.player_id, index) }} />
                   <div className="flex-1">
-                    <div className="text-xl font-bold text-white mb-1">{player.name}</div>
-                    <div className="flex items-center gap-4 text-sm text-slate-300">
-                      <span>Trilha: {player.position}/10</span>
-                      <span>•</span>
-                      <span>{player.cards.length} cartas restantes</span>
+                    <div className="text-xl font-bold text-white mb-1">{entry.player_id}</div>
+                    <div className="text-sm text-slate-300">
+                      Maior expedição: {entry.max_expedition} carta(s)
                     </div>
                   </div>
-                  
                   <div className="text-right">
-                    <div className="text-3xl font-bold text-white">{player.score}</div>
+                    <div className="text-3xl font-bold text-white">{entry.total_score}</div>
                     <div className="text-sm text-slate-400">pontos</div>
                   </div>
                 </div>
@@ -194,7 +151,6 @@ export default function GameEnd() {
           </div>
         </div>
 
-        {/* Action Buttons */}
         <div className="flex flex-col md:flex-row gap-4">
           <Button
             onClick={() => navigate('/')}
@@ -204,7 +160,6 @@ export default function GameEnd() {
             <Home className="w-5 h-5 mr-2" />
             Menu Principal
           </Button>
-          
           <Button
             onClick={playAgain}
             className="flex-1 bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white text-lg py-6"

--- a/frontend/src/app/pages/Join.tsx
+++ b/frontend/src/app/pages/Join.tsx
@@ -11,22 +11,22 @@ export default function Join() {
   const location = useLocation()
   const { setMyPlayerId, setGameId } = useGameStore()
 
-  const code: string = location.state?.code ?? ''
-  // Players list passed by the host (in the real game this will come from the backend)
-  const playersFromState: { name: string; color: string }[] = location.state?.players ?? [
-    { name: 'Jogador 1', color: '#ef4444' },
-    { name: 'Jogador 2', color: '#3b82f6' },
-    { name: 'Jogador 3', color: '#22c55e' },
-    { name: 'Jogador 4', color: '#f59e0b' },
-  ]
+  const gameId: string = location.state?.gameId ?? ''
+  const playerOrder: string[] = location.state?.playerOrder ?? []
+  const colorMap: Record<string, string> = location.state?.colorMap ?? {}
 
-  const [selected, setSelected] = useState<number | null>(null)
+  const [selected, setSelected] = useState<string | null>(null)
 
   const join = () => {
-    if (selected === null) return
-    setGameId(code)
-    setMyPlayerId(`player-${selected}`)
-    navigate('/game', { state: { players: playersFromState } })
+    if (!selected) return
+    setGameId(gameId)
+    setMyPlayerId(selected)
+    navigate('/game', { state: { gameCode: gameId } })
+  }
+
+  if (!gameId || playerOrder.length === 0) {
+    navigate('/')
+    return null
   }
 
   return (
@@ -38,27 +38,30 @@ export default function Join() {
       >
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-white mb-1">Entrar na Partida</h1>
-          <p className="text-amber-400 text-2xl font-mono tracking-widest">{code}</p>
+          <p className="text-slate-500 text-sm font-mono mt-1 break-all">{gameId}</p>
         </div>
 
         <Card className="bg-slate-800/80 backdrop-blur-xl border-slate-700 p-6">
           <p className="text-slate-400 text-sm mb-4">Selecione qual jogador você é nesta partida:</p>
 
           <div className="space-y-3 mb-6">
-            {playersFromState.map((player, index) => (
+            {playerOrder.map((playerName) => (
               <motion.button
-                key={index}
-                onClick={() => setSelected(index)}
+                key={playerName}
+                onClick={() => setSelected(playerName)}
                 whileTap={{ scale: 0.97 }}
                 className={`w-full flex items-center gap-3 p-4 rounded-xl border-2 transition-colors ${
-                  selected === index
+                  selected === playerName
                     ? 'border-amber-500 bg-amber-500/10'
                     : 'border-slate-600 bg-slate-700/50 hover:border-slate-500'
                 }`}
               >
-                <div className="w-10 h-10 rounded-full flex-shrink-0" style={{ backgroundColor: player.color }} />
-                <span className="text-white font-medium text-left">{player.name}</span>
-                {selected === index && (
+                <div
+                  className="w-10 h-10 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: colorMap[playerName] ?? '#888' }}
+                />
+                <span className="text-white font-medium text-left">{playerName}</span>
+                {selected === playerName && (
                   <span className="ml-auto text-amber-400 text-sm font-bold">Eu</span>
                 )}
               </motion.button>
@@ -67,11 +70,11 @@ export default function Join() {
 
           <Button
             onClick={join}
-            disabled={selected === null}
+            disabled={!selected}
             className="w-full bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white text-lg py-6 disabled:opacity-50"
           >
             <LogIn className="w-5 h-5 mr-2" />
-            Entrar como {selected !== null ? playersFromState[selected].name : '...'}
+            Entrar como {selected ?? '...'}
           </Button>
         </Card>
       </motion.div>

--- a/frontend/src/app/pages/Lobby.tsx
+++ b/frontend/src/app/pages/Lobby.tsx
@@ -4,84 +4,90 @@ import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
-import { Users, Plus, Minus, Play, LogIn, Copy, Check } from 'lucide-react';
+import { Users, Plus, Minus, Play, LogIn, Loader2 } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useGameStore } from '../../store/gameStore';
+import { gameApi } from '../../api/game';
+import { BackendGameState } from '../../api/types';
 import { toast } from 'sonner';
 import { Toaster } from '../components/ui/sonner';
 
 type Mode = 'home' | 'create' | 'join'
 
-function generateGameCode() {
-  return Math.random().toString(36).substring(2, 8).toUpperCase()
-}
+const PLAYER_COLORS = ['#ef4444', '#3b82f6', '#22c55e', '#f59e0b', '#8b5cf6', '#ec4899']
 
 export default function Lobby() {
   const navigate = useNavigate();
-  const { setGameId, setMyPlayerId } = useGameStore()
+  const { setPlayerColors } = useGameStore()
 
   const [mode, setMode] = useState<Mode>('home')
-  const [numPlayers, setNumPlayers] = useState(4);
+  const [numPlayers, setNumPlayers] = useState(4)
   const [players, setPlayers] = useState([
-    { name: 'Jogador 1', color: '#ef4444' },
-    { name: 'Jogador 2', color: '#3b82f6' },
-    { name: 'Jogador 3', color: '#22c55e' },
-    { name: 'Jogador 4', color: '#f59e0b' },
-  ]);
-  const [gameCode, setGameCode] = useState('')
-  const [codeCopied, setCodeCopied] = useState(false)
+    { name: 'Jogador 1', color: PLAYER_COLORS[0] },
+    { name: 'Jogador 2', color: PLAYER_COLORS[1] },
+    { name: 'Jogador 3', color: PLAYER_COLORS[2] },
+    { name: 'Jogador 4', color: PLAYER_COLORS[3] },
+  ])
 
-  // Join mode state
   const [joinCode, setJoinCode] = useState('')
-
-  const playerColors = ['#ef4444', '#3b82f6', '#22c55e', '#f59e0b', '#8b5cf6', '#ec4899'];
+  const [joinLoading, setJoinLoading] = useState(false)
 
   const addPlayer = () => {
     if (numPlayers < 6) {
-      const newNum = numPlayers + 1;
-      setNumPlayers(newNum);
-      setPlayers([...players, { name: `Jogador ${newNum}`, color: playerColors[newNum - 1] }]);
+      const n = numPlayers + 1
+      setNumPlayers(n)
+      setPlayers([...players, { name: `Jogador ${n}`, color: PLAYER_COLORS[n - 1] }])
     }
-  };
+  }
 
   const removePlayer = () => {
     if (numPlayers > 2) {
-      const newNum = numPlayers - 1;
-      setNumPlayers(newNum);
-      setPlayers(players.slice(0, newNum));
+      const n = numPlayers - 1
+      setNumPlayers(n)
+      setPlayers(players.slice(0, n))
     }
-  };
+  }
 
   const updatePlayerName = (index: number, name: string) => {
-    const updated = [...players];
-    updated[index].name = name;
-    setPlayers(updated);
-  };
-
-  const createGame = () => {
-    const code = generateGameCode()
-    setGameCode(code)
-    setGameId(code)
-    // Host is player 0 by default
-    setMyPlayerId('player-0')
+    const updated = [...players]
+    updated[index].name = name
+    setPlayers(updated)
   }
 
-  const copyCode = async () => {
-    await navigator.clipboard.writeText(gameCode)
-    setCodeCopied(true)
-    setTimeout(() => setCodeCopied(false), 2000)
+  const goToSetup = () => {
+    const colorMap: Record<string, string> = {}
+    players.forEach((p) => { colorMap[p.name] = p.color })
+    setPlayerColors(colorMap)
+    navigate('/setup', { state: { players } })
   }
 
-  const startGame = () => {
-    navigate('/setup', { state: { players } });
-  };
+  const goToJoin = async () => {
+    const code = joinCode.trim()
+    if (!code) { toast.error('Digite o código da partida'); return }
+    setJoinLoading(true)
+    try {
+      const res = await gameApi.getState(code)
+      const raw: BackendGameState = res.data
 
-  const goToJoin = () => {
-    if (!joinCode.trim()) {
-      toast.error('Digite o código da partida')
-      return
+      // Build color map from player_order (same deterministic order as adapters.ts)
+      const colorMap: Record<string, string> = {}
+      raw.player_order.forEach((pid, i) => {
+        colorMap[pid] = PLAYER_COLORS[i % PLAYER_COLORS.length]
+      })
+      setPlayerColors(colorMap)
+
+      navigate('/join', {
+        state: {
+          gameId: code,
+          playerOrder: raw.player_order,
+          colorMap,
+        },
+      })
+    } catch {
+      toast.error('Partida não encontrada. Verifique o código.')
+    } finally {
+      setJoinLoading(false)
     }
-    navigate('/join', { state: { code: joinCode.toUpperCase(), players } })
   }
 
   return (
@@ -103,7 +109,6 @@ export default function Lobby() {
           <p className="text-slate-400 text-lg">Prepare-se para a aventura arqueológica</p>
         </div>
 
-        {/* Home — choose mode */}
         {mode === 'home' && (
           <Card className="bg-slate-800/80 backdrop-blur-xl border-slate-700 p-6 md:p-8">
             <div className="space-y-4">
@@ -126,31 +131,15 @@ export default function Lobby() {
           </Card>
         )}
 
-        {/* Create game */}
         {mode === 'create' && (
           <Card className="bg-slate-800/80 backdrop-blur-xl border-slate-700 p-6 md:p-8">
             <button
-              onClick={() => { setMode('home'); setGameCode('') }}
+              onClick={() => setMode('home')}
               className="text-slate-400 hover:text-white text-sm mb-6 block"
             >
               ← Voltar
             </button>
 
-            {/* Game code */}
-            {gameCode ? (
-              <div className="mb-6 bg-slate-700/50 rounded-xl p-4 text-center">
-                <p className="text-slate-400 text-sm mb-1">Código da partida — compartilhe com os jogadores</p>
-                <div className="flex items-center justify-center gap-3">
-                  <span className="text-3xl font-bold text-amber-400 tracking-widest">{gameCode}</span>
-                  <button onClick={copyCode} className="text-slate-400 hover:text-white">
-                    {codeCopied ? <Check className="w-5 h-5 text-green-400" /> : <Copy className="w-5 h-5" />}
-                  </button>
-                </div>
-                <p className="text-slate-500 text-xs mt-2">Você é o Anfitrião (Jogador 1)</p>
-              </div>
-            ) : null}
-
-            {/* Player count */}
             <div className="mb-6">
               <Label className="text-white text-lg mb-3 block">Número de Jogadores</Label>
               <div className="flex items-center gap-4">
@@ -179,9 +168,8 @@ export default function Lobby() {
               </div>
             </div>
 
-            {/* Player names */}
             <div className="mb-6">
-              <Label className="text-white text-lg mb-3 block">Jogadores</Label>
+              <Label className="text-white text-lg mb-3 block">Nomes dos Jogadores</Label>
               <div className="space-y-3">
                 {players.map((player, index) => (
                   <motion.div
@@ -203,26 +191,16 @@ export default function Lobby() {
               </div>
             </div>
 
-            {!gameCode ? (
-              <Button
-                onClick={createGame}
-                className="w-full bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600 text-white text-lg py-6"
-              >
-                Gerar Código da Partida
-              </Button>
-            ) : (
-              <Button
-                onClick={startGame}
-                className="w-full bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white text-lg py-6"
-              >
-                <Play className="w-5 h-5 mr-2" />
-                Iniciar Jogo
-              </Button>
-            )}
+            <Button
+              onClick={goToSetup}
+              className="w-full bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white text-lg py-6"
+            >
+              <Play className="w-5 h-5 mr-2" />
+              Continuar para Configuração
+            </Button>
           </Card>
         )}
 
-        {/* Join game */}
         {mode === 'join' && (
           <Card className="bg-slate-800/80 backdrop-blur-xl border-slate-700 p-6 md:p-8">
             <button
@@ -235,22 +213,29 @@ export default function Lobby() {
               <Label className="text-white text-lg mb-3 block">Código da Partida</Label>
               <Input
                 value={joinCode}
-                onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
-                className="bg-slate-700 border-slate-600 text-white text-2xl text-center tracking-widest"
-                placeholder="XXXXXX"
-                maxLength={6}
+                onChange={(e) => setJoinCode(e.target.value.trim())}
+                className="bg-slate-700 border-slate-600 text-white text-xl text-center font-mono tracking-widest"
+                placeholder="Cole o código aqui"
+                onKeyDown={(e) => e.key === 'Enter' && goToJoin()}
               />
+              <p className="text-slate-500 text-xs mt-2">
+                O anfitrião verá o código após criar a partida na tela de configuração.
+              </p>
             </div>
             <Button
               onClick={goToJoin}
+              disabled={joinLoading}
               className="w-full bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white text-lg py-6"
             >
-              <LogIn className="w-5 h-5 mr-2" />
+              {joinLoading
+                ? <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                : <LogIn className="w-5 h-5 mr-2" />
+              }
               Entrar
             </Button>
           </Card>
         )}
       </motion.div>
     </div>
-  );
+  )
 }

--- a/frontend/src/app/pages/SeasonEnd.tsx
+++ b/frontend/src/app/pages/SeasonEnd.tsx
@@ -1,47 +1,66 @@
+import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { Button } from '../components/ui/button';
 import { Player } from '../types';
 import { motion } from 'motion/react';
-import { Trophy, TrendingUp, Award, ArrowRight } from 'lucide-react';
-import { useEffect } from 'react';
+import { Trophy, TrendingUp, Award, ArrowRight, Loader2 } from 'lucide-react';
+import { gameApi } from '../../api/game';
+import { adaptGameState } from '../../api/adapters';
+import { useGameStore } from '../../store/gameStore';
+import { BackendGameState } from '../../api/types';
+import { toast } from 'sonner';
+import { Toaster } from '../components/ui/sonner';
 
 export default function SeasonEnd() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { players, season, monkeyEnd } = location.state || {};
+  const { gameId: storedGameId, playerColors } = useGameStore()
 
-  // Redirect if no state data
+  const gid: string = location.state?.gameId ?? storedGameId ?? ''
+
+  const [players, setPlayers] = useState<Player[]>([])
+  const [season, setSeason] = useState(1)
+  const [monkeysFound, setMonkeysFound] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [continuing, setContinuing] = useState(false)
+
   useEffect(() => {
-    if (!players || !season) {
-      navigate('/');
-    }
-  }, [players, season, navigate]);
+    if (!gid) { navigate('/'); return }
+    gameApi.getState(gid).then((res) => {
+      const raw: BackendGameState = res.data
+      const adapted = adaptGameState(raw, playerColors)
+      setPlayers(adapted.players)
+      setSeason(adapted.season)
+      setMonkeysFound(adapted.monkeysFound)
+      setLoading(false)
+    }).catch(() => navigate('/'))
+  }, [gid, navigate, playerColors])
 
-  // Guard clause
-  if (!players || !season) {
-    return null;
+  const nextSeason = async () => {
+    setContinuing(true)
+    try {
+      await gameApi.nextSeason(gid)
+      navigate('/game', { state: { gameCode: gid } })
+    } catch (err: any) {
+      toast.error(err?.response?.data?.detail ?? 'Erro ao avançar temporada')
+      setContinuing(false)
+    }
   }
 
-  // Sort players by score
-  const sortedPlayers = [...players].sort((a, b) => b.score - a.score);
-  const leader = sortedPlayers[0];
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center">
+        <Loader2 className="w-10 h-10 text-amber-400 animate-spin" />
+      </div>
+    )
+  }
 
-  const nextSeason = () => {
-    // Check if game should end (e.g., after season 3)
-    if (season >= 3) {
-      navigate('/game-end', { state: { players } });
-    } else {
-      navigate('/game', { 
-        state: { 
-          players, 
-          season: season + 1 
-        } 
-      });
-    }
-  };
+  const sortedPlayers = [...players].sort((a, b) => b.score - a.score)
+  const leader = sortedPlayers[0]
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-4">
+      <Toaster position="top-center" />
       <motion.div
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
@@ -49,61 +68,42 @@ export default function SeasonEnd() {
       >
         {/* Header */}
         <div className="text-center mb-8">
-          <motion.div
-            initial={{ scale: 0 }}
-            animate={{ scale: 1 }}
-            transition={{ delay: 0.2, type: 'spring' }}
-            className="inline-block mb-4"
-          >
+          <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} transition={{ delay: 0.2, type: 'spring' }} className="inline-block mb-4">
             <Award className="w-20 h-20 text-amber-500" />
           </motion.div>
-          
-          <h1 className="text-4xl md:text-6xl font-bold text-white mb-2">
-            Fim da Temporada {season}
-          </h1>
+          <h1 className="text-4xl md:text-6xl font-bold text-white mb-2">Fim da Temporada {season}</h1>
           <p className="text-slate-400 text-lg">Resumo da rodada</p>
-          
-          {monkeyEnd && (
+          {monkeysFound >= 3 && (
             <motion.div
-              initial={{ scale: 0 }}
-              animate={{ scale: 1 }}
-              transition={{ delay: 0.3, type: 'spring' }}
+              initial={{ scale: 0 }} animate={{ scale: 1 }} transition={{ delay: 0.3, type: 'spring' }}
               className="mt-4 inline-block bg-orange-500/30 border-2 border-orange-500 rounded-lg px-6 py-3"
             >
-              <p className="text-2xl font-bold text-orange-200">
-                🙈🙉🙊 3 Macacos Revelados!
-              </p>
-              <p className="text-sm text-orange-300 mt-1">
-                A temporada terminou prematuramente
-              </p>
+              <p className="text-2xl font-bold text-orange-200">🙈🙉🙊 3 Macacos Revelados!</p>
+              <p className="text-sm text-orange-300 mt-1">A temporada terminou prematuramente</p>
             </motion.div>
           )}
         </div>
 
-        {/* Leader Highlight */}
-        <motion.div
-          initial={{ y: 20, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{ delay: 0.4 }}
-          className="bg-gradient-to-br from-amber-500 to-orange-500 rounded-2xl p-6 mb-6"
-        >
-          <div className="flex items-center gap-4">
-            <Trophy className="w-12 h-12 text-white" />
-            <div className="flex-1">
-              <div className="text-white/80 text-sm mb-1">Líder da Temporada</div>
-              <div className="flex items-center gap-3">
-                <div 
-                  className="w-10 h-10 rounded-full"
-                  style={{ backgroundColor: leader.color }}
-                />
-                <div>
-                  <h3 className="text-2xl font-bold text-white">{leader.name}</h3>
-                  <p className="text-white/90">{leader.score} pontos</p>
+        {/* Leader */}
+        {leader && (
+          <motion.div initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ delay: 0.4 }}
+            className="bg-gradient-to-br from-amber-500 to-orange-500 rounded-2xl p-6 mb-6"
+          >
+            <div className="flex items-center gap-4">
+              <Trophy className="w-12 h-12 text-white" />
+              <div className="flex-1">
+                <div className="text-white/80 text-sm mb-1">Líder da Temporada</div>
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-full" style={{ backgroundColor: leader.color }} />
+                  <div>
+                    <h3 className="text-2xl font-bold text-white">{leader.name}</h3>
+                    <p className="text-white/90">{leader.score} pontos</p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </motion.div>
+          </motion.div>
+        )}
 
         {/* Rankings */}
         <div className="bg-slate-800/80 backdrop-blur-xl rounded-2xl p-6 mb-6">
@@ -111,35 +111,21 @@ export default function SeasonEnd() {
             <TrendingUp className="w-6 h-6 text-blue-400" />
             Classificação
           </h2>
-          
           <div className="space-y-3">
-            {sortedPlayers.map((player: Player, index) => (
+            {sortedPlayers.map((player, index) => (
               <motion.div
                 key={player.id}
                 initial={{ x: -20, opacity: 0 }}
                 animate={{ x: 0, opacity: 1 }}
                 transition={{ delay: 0.5 + index * 0.1 }}
-                className={`
-                  flex items-center gap-4 p-4 rounded-lg
-                  ${index === 0 ? 'bg-amber-500/20' : 'bg-slate-700/50'}
-                `}
+                className={`flex items-center gap-4 p-4 rounded-lg ${index === 0 ? 'bg-amber-500/20' : 'bg-slate-700/50'}`}
               >
-                <div className="text-2xl font-bold text-white w-8">
-                  #{index + 1}
-                </div>
-                
-                <div 
-                  className="w-10 h-10 rounded-full"
-                  style={{ backgroundColor: player.color }}
-                />
-                
+                <div className="text-2xl font-bold text-white w-8">#{index + 1}</div>
+                <div className="w-10 h-10 rounded-full" style={{ backgroundColor: player.color }} />
                 <div className="flex-1">
                   <div className="font-bold text-white">{player.name}</div>
-                  <div className="text-sm text-slate-400">
-                    Posição na trilha: {player.position}/10
-                  </div>
+                  <div className="text-sm text-slate-400">Posição: {player.position}</div>
                 </div>
-                
                 <div className="text-right">
                   <div className="text-2xl font-bold text-white">{player.score}</div>
                   <div className="text-sm text-slate-400">pontos</div>
@@ -149,17 +135,13 @@ export default function SeasonEnd() {
           </div>
         </div>
 
-        {/* Progress Summary */}
+        {/* Tracks progress */}
         <div className="bg-slate-800/80 backdrop-blur-xl rounded-2xl p-6 mb-6">
           <h3 className="text-lg font-bold text-white mb-4">Progresso nas Trilhas</h3>
-          
-          {sortedPlayers.map((player: Player) => (
+          {sortedPlayers.map((player) => (
             <div key={player.id} className="mb-4 last:mb-0">
-              <div className="flex items-center gap-2 mb-2">
-                <div 
-                  className="w-4 h-4 rounded-full"
-                  style={{ backgroundColor: player.color }}
-                />
+              <div className="flex items-center gap-2 mb-1">
+                <div className="w-4 h-4 rounded-full" style={{ backgroundColor: player.color }} />
                 <span className="text-sm text-white font-medium">{player.name}</span>
                 <span className="text-xs text-slate-400 ml-auto">{player.position}/10</span>
               </div>
@@ -170,11 +152,7 @@ export default function SeasonEnd() {
                     initial={{ scaleX: 0 }}
                     animate={{ scaleX: 1 }}
                     transition={{ delay: 0.8 + i * 0.05 }}
-                    className={`w-full h-3 rounded ${
-                      i < player.position 
-                        ? 'bg-gradient-to-r from-amber-500 to-orange-500' 
-                        : 'bg-slate-700'
-                    }`}
+                    className={`w-full h-3 rounded ${i < player.position ? 'bg-gradient-to-r from-amber-500 to-orange-500' : 'bg-slate-700'}`}
                   />
                 ))}
               </div>
@@ -182,13 +160,13 @@ export default function SeasonEnd() {
           ))}
         </div>
 
-        {/* Continue Button */}
         <Button
           onClick={nextSeason}
+          disabled={continuing}
           className="w-full bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white text-lg py-6"
         >
-          {season >= 3 ? 'Ver Resultado Final' : 'Próxima Temporada'}
-          <ArrowRight className="w-5 h-5 ml-2" />
+          {continuing ? <Loader2 className="w-5 h-5 mr-2 animate-spin" /> : <ArrowRight className="w-5 h-5 mr-2" />}
+          Próxima Temporada
         </Button>
       </motion.div>
     </div>

--- a/frontend/src/app/pages/Setup.tsx
+++ b/frontend/src/app/pages/Setup.tsx
@@ -2,197 +2,227 @@ import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
-import { Role } from '../types';
 import { motion } from 'motion/react';
-import { CheckCircle2, Circle, MapPin, Play } from 'lucide-react';
+import { CheckCircle2, Circle, MapPin, Play, Loader2, Copy, Check, ArrowRight } from 'lucide-react';
+import { gameApi } from '../../api/game';
+import { useGameStore } from '../../store/gameStore';
+import { toast } from 'sonner';
+import { Toaster } from '../components/ui/sonner';
 
-const availableRoles: Role[] = [
-  {
-    id: '1',
-    name: 'Arqueólogo',
-    description: 'Especialista em escavações',
-    ability: '+1 carta ao comprar do deck',
-  },
-  {
-    id: '2',
-    name: 'Explorador',
-    description: 'Mestre das expedições',
-    ability: 'Pode fazer expedições com 2 cartas',
-  },
-  {
-    id: '3',
-    name: 'Pesquisador',
-    description: 'Expert em análises',
-    ability: 'Ver 2 cartas extras do mercado',
-  },
-  {
-    id: '4',
-    name: 'Patrocinador',
-    description: 'Rico e influente',
-    ability: 'Começa com +2 pontos',
-  },
-  {
-    id: '5',
-    name: 'Guia',
-    description: 'Conhecedor dos caminhos',
-    ability: '+1 movimento na trilha',
-  },
-  {
-    id: '6',
-    name: 'Colecionador',
-    description: 'Acumula artefatos',
-    ability: 'Limite de mão: 12 cartas',
-  },
-];
+const AVAILABLE_ROLES = [
+  'Botânico', 'Linguista', 'Professor', 'Explorador', 'Guia',
+  'Médico', 'Mercenário', 'Cartógrafo', 'Piloto', 'Patrono',
+  'Curador', 'Fotógrafo', 'Estudante',
+]
 
-const archaeologicalSites = [
-  { id: '1', name: 'Pirâmides do Egito', icon: '🏜️' },
-  { id: '2', name: 'Machu Picchu', icon: '⛰️' },
-  { id: '3', name: 'Angkor Wat', icon: '🏯' },
-  { id: '4', name: 'Stonehenge', icon: '🗿' },
-];
+const SITES = [
+  'América do Norte', 'América do Sul', 'Europa', 'África', 'Ásia', 'Oceania',
+]
+
+type SiteSide = 'A' | 'B'
 
 export default function Setup() {
   const navigate = useNavigate();
   const location = useLocation();
-  const players = location.state?.players || [];
-  
-  const [selectedRoles, setSelectedRoles] = useState<{ [playerId: number]: Role }>({});
-  const [selectedSites, setSelectedSites] = useState<string[]>(['1', '2', '3']);
+  const players: { name: string; color: string }[] = location.state?.players || [];
 
-  const toggleRole = (playerIndex: number, role: Role) => {
-    setSelectedRoles({
-      ...selectedRoles,
-      [playerIndex]: role,
-    });
-  };
+  const { setGameId, setMyPlayerId } = useGameStore()
 
-  const toggleSite = (siteId: string) => {
-    if (selectedSites.includes(siteId)) {
-      setSelectedSites(selectedSites.filter(id => id !== siteId));
-    } else {
-      setSelectedSites([...selectedSites, siteId]);
+  const [selectedRoles, setSelectedRoles] = useState<Set<string>>(new Set())
+  const [siteConfigs, setSiteConfigs] = useState<Record<string, SiteSide>>(
+    Object.fromEntries(SITES.map((s) => [s, 'A' as SiteSide]))
+  )
+  const [loading, setLoading] = useState(false)
+  const [createdGameId, setCreatedGameId] = useState<string | null>(null)
+  const [codeCopied, setCodeCopied] = useState(false)
+
+  const toggleRole = (role: string) => {
+    setSelectedRoles((prev) => {
+      const next = new Set(prev)
+      if (next.has(role)) next.delete(role)
+      else next.add(role)
+      return next
+    })
+  }
+
+  const toggleSite = (site: string) => {
+    setSiteConfigs((prev) => ({
+      ...prev,
+      [site]: prev[site] === 'A' ? 'B' : 'A',
+    }))
+  }
+
+  const createGame = async () => {
+    if (selectedRoles.size < 6) {
+      toast.error('Selecione pelo menos 6 papéis para o baralho')
+      return
     }
-  };
+    setLoading(true)
+    try {
+      const res = await gameApi.createGame({
+        player_ids: players.map((p) => p.name),
+        selected_roles: Array.from(selectedRoles),
+        site_configs: siteConfigs,
+      })
+      const gameId: string = res.data.game_id
+      setGameId(gameId)
+      setMyPlayerId(players[0].name)
+      setCreatedGameId(gameId)
+    } catch (err: any) {
+      toast.error(err?.response?.data?.detail ?? 'Erro ao criar partida')
+    } finally {
+      setLoading(false)
+    }
+  }
 
-  const startGame = () => {
-    navigate('/game', { state: { players, selectedRoles, selectedSites } });
-  };
+  const copyCode = async () => {
+    if (!createdGameId) return
+    await navigator.clipboard.writeText(createdGameId)
+    setCodeCopied(true)
+    setTimeout(() => setCodeCopied(false), 2000)
+  }
 
-  const allRolesSelected = players.length === Object.keys(selectedRoles).length;
+  const goToGame = () => {
+    navigate('/game', { state: { gameCode: createdGameId } })
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-4 overflow-y-auto">
-      <div className="max-w-6xl mx-auto py-8">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-        >
+      <Toaster position="top-center" />
+      <div className="max-w-4xl mx-auto py-8">
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
           <h1 className="text-3xl md:text-5xl font-bold text-white mb-2 text-center">
             Configuração da Partida
           </h1>
           <p className="text-slate-400 text-center mb-8">
-            Escolha os papéis e os sítios arqueológicos
+            Escolha os papéis do baralho e as configurações dos sítios
           </p>
 
-          {/* Role Selection */}
-          <div className="mb-8">
-            <h2 className="text-2xl font-bold text-white mb-4 flex items-center gap-2">
-              <Circle className="w-6 h-6 text-blue-400" />
-              Seleção de Papéis
-            </h2>
-            
-            <div className="grid gap-6">
-              {players.map((player: any, index: number) => (
-                <Card key={index} className="bg-slate-800/80 backdrop-blur-xl border-slate-700 p-4 md:p-6">
-                  <div className="flex items-center gap-3 mb-4">
-                    <div 
-                      className="w-10 h-10 rounded-full flex-shrink-0"
-                      style={{ backgroundColor: player.color }}
-                    />
-                    <h3 className="text-xl font-bold text-white">{player.name}</h3>
-                  </div>
-                  
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-                    {availableRoles.map((role) => {
-                      const isSelected = selectedRoles[index]?.id === role.id;
-                      return (
-                        <motion.div
-                          key={role.id}
-                          whileHover={{ scale: 1.02 }}
-                          whileTap={{ scale: 0.98 }}
-                          onClick={() => toggleRole(index, role)}
-                          className={`
-                            p-4 rounded-lg cursor-pointer transition-all
-                            ${isSelected 
-                              ? 'bg-gradient-to-br from-amber-500 to-orange-500 ring-2 ring-amber-400' 
-                              : 'bg-slate-700/50 hover:bg-slate-700'
-                            }
-                          `}
-                        >
-                          <div className="flex items-start justify-between mb-2">
-                            <h4 className="font-bold text-white text-sm">{role.name}</h4>
-                            {isSelected ? (
-                              <CheckCircle2 className="w-5 h-5 text-white flex-shrink-0" />
-                            ) : (
-                              <Circle className="w-5 h-5 text-slate-400 flex-shrink-0" />
-                            )}
-                          </div>
-                          <p className="text-xs text-slate-300 mb-1">{role.description}</p>
-                          <p className="text-xs text-amber-300 font-semibold">{role.ability}</p>
-                        </motion.div>
-                      );
-                    })}
-                  </div>
-                </Card>
-              ))}
-            </div>
-          </div>
+          {/* Game code — shown after creation */}
+          {createdGameId && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="bg-green-500/15 border-2 border-green-500 rounded-2xl p-6 mb-8 text-center"
+            >
+              <p className="text-green-300 font-semibold mb-2">Partida criada! Compartilhe o código com os outros jogadores:</p>
+              <div className="flex items-center justify-center gap-3 mb-3">
+                <span className="text-2xl font-mono text-white bg-slate-800 rounded-xl px-4 py-2 select-all break-all">
+                  {createdGameId}
+                </span>
+                <button onClick={copyCode} className="text-slate-400 hover:text-white flex-shrink-0">
+                  {codeCopied ? <Check className="w-6 h-6 text-green-400" /> : <Copy className="w-6 h-6" />}
+                </button>
+              </div>
+              <p className="text-slate-400 text-sm">Os outros jogadores entram em "Entrar em Partida" e colam esse código.</p>
+            </motion.div>
+          )}
 
-          {/* Archaeological Sites */}
-          <div className="mb-8">
-            <h2 className="text-2xl font-bold text-white mb-4 flex items-center gap-2">
-              <MapPin className="w-6 h-6 text-green-400" />
-              Sítios Arqueológicos
+          {/* Role selection */}
+          <Card className="bg-slate-800/80 backdrop-blur-xl border-slate-700 p-6 mb-8">
+            <h2 className="text-xl font-bold text-white mb-1 flex items-center gap-2">
+              <Circle className="w-5 h-5 text-blue-400" />
+              Papéis no Baralho
             </h2>
-            
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              {archaeologicalSites.map((site) => {
-                const isSelected = selectedSites.includes(site.id);
+            <p className="text-slate-400 text-sm mb-4">
+              Selecione os papéis disponíveis ({selectedRoles.size} selecionados — mínimo 6)
+            </p>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              {AVAILABLE_ROLES.map((role) => {
+                const isSelected = selectedRoles.has(role)
                 return (
                   <motion.div
-                    key={site.id}
-                    whileHover={{ scale: 1.05 }}
-                    whileTap={{ scale: 0.95 }}
-                    onClick={() => toggleSite(site.id)}
+                    key={role}
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                    onClick={() => !createdGameId && toggleRole(role)}
                     className={`
-                      p-6 rounded-xl cursor-pointer transition-all text-center
+                      p-3 rounded-lg transition-all flex items-center justify-between
+                      ${createdGameId ? 'opacity-60 cursor-default' : 'cursor-pointer'}
                       ${isSelected
-                        ? 'bg-gradient-to-br from-green-500 to-emerald-500 ring-2 ring-green-400'
-                        : 'bg-slate-800/50 hover:bg-slate-700/50'
+                        ? 'bg-gradient-to-br from-amber-500 to-orange-500 ring-2 ring-amber-400'
+                        : 'bg-slate-700/50 hover:bg-slate-700'
                       }
                     `}
                   >
-                    <div className="text-4xl mb-2">{site.icon}</div>
-                    <h4 className="font-bold text-white text-sm">{site.name}</h4>
-                    {isSelected && (
-                      <CheckCircle2 className="w-5 h-5 text-white mx-auto mt-2" />
-                    )}
+                    <span className="font-medium text-white text-sm">{role}</span>
+                    {isSelected
+                      ? <CheckCircle2 className="w-4 h-4 text-white flex-shrink-0" />
+                      : <Circle className="w-4 h-4 text-slate-400 flex-shrink-0" />
+                    }
                   </motion.div>
-                );
+                )
               })}
             </div>
-          </div>
+          </Card>
 
-          {/* Confirm Button */}
-          <Button
-            onClick={startGame}
-            disabled={!allRolesSelected || selectedSites.length < 2}
-            className="w-full bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white text-lg py-6 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <Play className="w-5 h-5 mr-2" />
-            Confirmar Setup
-          </Button>
+          {/* Site configuration */}
+          <Card className="bg-slate-800/80 backdrop-blur-xl border-slate-700 p-6 mb-8">
+            <h2 className="text-xl font-bold text-white mb-1 flex items-center gap-2">
+              <MapPin className="w-5 h-5 text-green-400" />
+              Sítios Arqueológicos
+            </h2>
+            <p className="text-slate-400 text-sm mb-4">
+              Lado A (Básico) ou Lado B (Avançado) — clique para alternar
+            </p>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              {SITES.map((site) => {
+                const side = siteConfigs[site]
+                return (
+                  <motion.div
+                    key={site}
+                    whileHover={{ scale: createdGameId ? 1 : 1.02 }}
+                    whileTap={{ scale: createdGameId ? 1 : 0.98 }}
+                    onClick={() => !createdGameId && toggleSite(site)}
+                    className={`p-4 rounded-xl text-center ${createdGameId ? 'opacity-60 cursor-default' : 'cursor-pointer bg-slate-700/50 hover:bg-slate-700'}`}
+                  >
+                    <div className="text-white font-bold text-sm mb-2">{site}</div>
+                    <div className={`
+                      inline-block px-3 py-1 rounded-full text-xs font-bold
+                      ${side === 'A'
+                        ? 'bg-blue-500/30 text-blue-300 ring-1 ring-blue-500'
+                        : 'bg-purple-500/30 text-purple-300 ring-1 ring-purple-500'
+                      }
+                    `}>
+                      Lado {side}
+                    </div>
+                  </motion.div>
+                )
+              })}
+            </div>
+          </Card>
+
+          {/* Players */}
+          <Card className="bg-slate-800/80 backdrop-blur-xl border-slate-700 p-6 mb-8">
+            <h2 className="text-xl font-bold text-white mb-4">Jogadores</h2>
+            <div className="flex flex-wrap gap-3">
+              {players.map((p) => (
+                <div key={p.name} className="flex items-center gap-2 bg-slate-700/50 rounded-lg px-3 py-2">
+                  <div className="w-4 h-4 rounded-full" style={{ backgroundColor: p.color }} />
+                  <span className="text-white text-sm font-medium">{p.name}</span>
+                </div>
+              ))}
+            </div>
+          </Card>
+
+          {!createdGameId ? (
+            <Button
+              onClick={createGame}
+              disabled={selectedRoles.size < 6 || loading}
+              className="w-full bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white text-lg py-6 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? <Loader2 className="w-5 h-5 mr-2 animate-spin" /> : <Play className="w-5 h-5 mr-2" />}
+              Criar Partida
+            </Button>
+          ) : (
+            <Button
+              onClick={goToGame}
+              className="w-full bg-gradient-to-r from-green-500 to-emerald-500 hover:from-green-600 hover:to-emerald-600 text-white text-lg py-6"
+            >
+              <ArrowRight className="w-5 h-5 mr-2" />
+              Ir para o Jogo (como {players[0]?.name})
+            </Button>
+          )}
         </motion.div>
       </div>
     </div>

--- a/frontend/src/app/types.ts
+++ b/frontend/src/app/types.ts
@@ -6,7 +6,9 @@ export interface GameCard {
   color: CardColor;
   function: CardFunction;
   value: number;
-  monkeyType?: 'see' | 'hear' | 'speak'; // Para os três macacos sábios
+  role?: string;
+  region?: string;
+  monkeyType?: 'see' | 'hear' | 'speak';
 }
 
 export interface Player {
@@ -15,7 +17,8 @@ export interface Player {
   color: string;
   score: number;
   cards: GameCard[];
-  position: number; // posição na trilha
+  position: number;
+  tracks?: Record<string, number>;
 }
 
 export interface Role {

--- a/frontend/src/store/gameStore.ts
+++ b/frontend/src/store/gameStore.ts
@@ -1,69 +1,32 @@
 import { create } from 'zustand'
 
-export type CardColor = 'red' | 'blue' | 'green' | 'yellow' | 'purple'
-export type CardFunction = 'excavation' | 'transport' | 'research' | 'funding' | 'artifact' | 'monkey'
-
-export interface GameCard {
-  id: string
-  color: CardColor
-  function: CardFunction
-  value: number
-  monkeyType?: 'see' | 'hear' | 'speak'
-}
-
-export interface Player {
-  id: string
-  name: string
-  color: string
-  role: string
-  score: number
-  position: number
-  cards: GameCard[]
-}
-
-export interface GameState {
+export interface GameStore {
   gameId: string | null
   myPlayerId: string | null
-  players: Player[]
-  currentPlayerIndex: number
-  market: GameCard[]
-  season: number
-  revealedMonkeys: number
-  phase: 'lobby' | 'setup' | 'playing' | 'expedition' | 'season-end' | 'game-end'
-  selectedCards: GameCard[]
-  sites: string[]
+  playerColors: Record<string, string>
 
   setGameId: (id: string) => void
   setMyPlayerId: (id: string | null) => void
-  setPlayers: (players: Player[]) => void
-  setMarket: (market: GameCard[]) => void
-  setCurrentPlayer: (index: number) => void
-  setSeason: (season: number) => void
-  setRevealedMonkeys: (count: number) => void
-  setPhase: (phase: GameState['phase']) => void
-  setSelectedCards: (cards: GameCard[]) => void
-  setSites: (sites: string[]) => void
+  setPlayerColors: (colors: Record<string, string>) => void
   reset: () => void
 }
 
-const PLAYER_ID_KEY = 'archeos_myPlayerId'
 const GAME_ID_KEY = 'archeos_gameId'
+const PLAYER_ID_KEY = 'archeos_myPlayerId'
+const PLAYER_COLORS_KEY = 'archeos_playerColors'
 
-const initialState = {
-  gameId: localStorage.getItem(GAME_ID_KEY) ?? null,
-  myPlayerId: localStorage.getItem(PLAYER_ID_KEY) ?? null,
-  players: [],
-  currentPlayerIndex: 0,
-  market: [],
-  season: 1,
-  revealedMonkeys: 0,
-  phase: 'lobby' as const,
-  selectedCards: [],
-  sites: [],
+function loadPlayerColors(): Record<string, string> {
+  try {
+    return JSON.parse(localStorage.getItem(PLAYER_COLORS_KEY) ?? '{}')
+  } catch {
+    return {}
+  }
 }
 
-export const useGameStore = create<GameState>((set) => ({
-  ...initialState,
+export const useGameStore = create<GameStore>((set) => ({
+  gameId: localStorage.getItem(GAME_ID_KEY) ?? null,
+  myPlayerId: localStorage.getItem(PLAYER_ID_KEY) ?? null,
+  playerColors: loadPlayerColors(),
 
   setGameId: (id) => {
     localStorage.setItem(GAME_ID_KEY, id)
@@ -74,17 +37,14 @@ export const useGameStore = create<GameState>((set) => ({
     else localStorage.removeItem(PLAYER_ID_KEY)
     set({ myPlayerId: id })
   },
-  setPlayers: (players) => set({ players }),
-  setMarket: (market) => set({ market }),
-  setCurrentPlayer: (index) => set({ currentPlayerIndex: index }),
-  setSeason: (season) => set({ season }),
-  setRevealedMonkeys: (count) => set({ revealedMonkeys: count }),
-  setPhase: (phase) => set({ phase }),
-  setSelectedCards: (cards) => set({ selectedCards: cards }),
-  setSites: (sites) => set({ sites }),
+  setPlayerColors: (colors) => {
+    localStorage.setItem(PLAYER_COLORS_KEY, JSON.stringify(colors))
+    set({ playerColors: colors })
+  },
   reset: () => {
-    localStorage.removeItem(PLAYER_ID_KEY)
     localStorage.removeItem(GAME_ID_KEY)
-    set({ ...initialState, gameId: null, myPlayerId: null })
+    localStorage.removeItem(PLAYER_ID_KEY)
+    localStorage.removeItem(PLAYER_COLORS_KEY)
+    set({ gameId: null, myPlayerId: null, playerColors: {} })
   },
 }))

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,5 +20,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/app/components/ui/calendar.tsx"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:8000',
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
## O que foi feito

- Conexão completa do frontend com a API REST do backend
- Fluxo multiplayer real: cada dispositivo se identifica como um jogador, vê o jogo mas só age na sua vez
- A mão de cada jogador é privada — outros só veem a quantidade de cartas
- Polling a cada 3s para manter o estado sincronizado entre dispositivos

## Páginas alteradas

- **Lobby**: modo criar (configura jogadores) e modo entrar (busca estado real no backend pelo código)
- **Setup**: seleção de papéis e configuração de sítios (Lado A/B), exibe o `game_id` após criação para compartilhar
- **Game**: polling, ações bloqueadas fora do turno, mão colapsável quando observando
- **Expedition**: envia `card_indices` e `leader_index` para o backend
- **SeasonEnd**: busca estado real e chama `/ready` para avançar
- **GameEnd**: exibe ranking do endpoint `/summary`
- **Join**: busca lista de jogadores do backend, usa nome como `player_id`

## Arquivos novos

- `src/api/types.ts` — interfaces TypeScript do modelo do backend
- `src/api/adapters.ts` — conversão região→cor e papel→função
- `src/vite-env.d.ts` — tipos do Vite

## Fixes técnicos

- Proxy Vite corrigido com `rewrite` para remover o prefixo `/api`
- Store simplificado: apenas `gameId`, `myPlayerId` e `playerColors`
- Join usa nome do jogador como `player_id` (igual ao backend)

## Issues fechadas

Closes #2, #3, #4, #5, #6, #8, #9, #10, #11, #13, #14, #15, #49, #50, #51