### PR TITLE
fix: pontuação de expedição, cores e poder do líder

### DIFF
--- a/backend/app/api/routes_game.py
+++ b/backend/app/api/routes_game.py
@@ -89,8 +89,9 @@ async def api_play_expedition(
         save_game_state(db, session)
         
         return {
-            "message": "Expedição jogada com sucesso", 
+            "message": "Expedição jogada com sucesso",
             "expedition_size": len(expedition.cards),
+            "points_earned": player.score,
             "next_turn": session.current_turn_player_id
         }
     except ValueError as e:

--- a/backend/app/core/game_engine.py
+++ b/backend/app/core/game_engine.py
@@ -176,6 +176,7 @@ def play_expedition(
             
     expedition = Expedition(cards=cards.copy(), leader=leader, color_matched=color_match)
     player.expeditions_played.append(expedition)
+    player.score += calculate_points(get_expedition_effective_size(expedition))
     return expedition
 
 def advance_turn(session: GameSession):
@@ -193,14 +194,8 @@ def validate_player_turn(session: GameSession, player_id: str):
 def end_season(session: GameSession) -> dict:
     """Finaliza a temporada e aplica efeitos oficiais (RF34, RF36, RF38)"""
     
-    # 1. PONTUAÇÃO DE EXPEDIÇÕES (Incluindo bônus do Fotógrafo) 
+    # 1. PONTUAÇÃO DE RELÍQUIAS (expedições já pontuam em tempo real ao serem jogadas)
     for player in session.players.values():
-        for expedition in player.expeditions_played:
-            # RF36: Aplica o tamanho efetivo (considerando +1 do Fotógrafo) 
-            tamanho_pontuavel = get_expedition_effective_size(expedition)
-            player.score += calculate_points(tamanho_pontuavel)
-        
-        # RF41/Manual: Aplica a pontuação progressiva das Relíquias (Curador) 
         player.score += calculate_relic_score(player.relics)
 
     # 2. LINGUISTA: +2 pontos apenas para o líder

--- a/frontend/src/api/adapters.ts
+++ b/frontend/src/api/adapters.ts
@@ -7,7 +7,7 @@ const REGION_TO_COLOR: Record<string, CardColor> = {
   'Europa': 'blue',
   'África': 'yellow',
   'Ásia': 'purple',
-  'Oceania': 'red',
+  'Oceania': 'orange',
   'Especial': 'red',
 }
 

--- a/frontend/src/app/components/GameCard.tsx
+++ b/frontend/src/app/components/GameCard.tsx
@@ -15,6 +15,7 @@ const colorMap = {
   green: 'bg-gradient-to-br from-green-500 to-green-700',
   yellow: 'bg-gradient-to-br from-yellow-500 to-yellow-700',
   purple: 'bg-gradient-to-br from-purple-500 to-purple-700',
+  orange: 'bg-gradient-to-br from-orange-500 to-orange-700',
 };
 
 const functionIcons = {

--- a/frontend/src/app/pages/Expedition.tsx
+++ b/frontend/src/app/pages/Expedition.tsx
@@ -20,6 +20,22 @@ export default function Expedition() {
   }
   const { gameId, playerId, selectedIndices, selectedCards } = state
 
+  const LEADER_ABILITIES: Record<string, string> = {
+    'Guia':       'Sempre avança na trilha da região, independente do tamanho da expedição.',
+    'Linguista':  'Avança na trilha do Linguista. O jogador com mais avanços ganha +2 pontos no fim da temporada.',
+    'Professor':  'Escolha qualquer trilha para avançar. Acumula tokens — maior soma avança, menor recua no fim da temporada.',
+    'Piloto':     'Escolha qualquer trilha para avançar.',
+    'Estudante':  'Não avança na trilha de nenhuma região.',
+    'Médico':     'Mantém todas as cartas na mão após a expedição (não descarta).',
+    'Cartógrafo': 'Mantém as cartas na mão e ganha um turno extra se ainda tiver cartas.',
+    'Patrono':    'Compra N cartas do baralho, onde N é o tamanho da expedição.',
+    'Botânico':   'A próxima carta comprada do baralho vai para a sua mão.',
+    'Curador':    'Ganha 1 relíquia. Relíquias valem pontos progressivos no fim da temporada.',
+    'Fotógrafo':  'Conta +1 no tamanho efetivo da expedição para pontuação e avanço de trilha.',
+    'Explorador': 'Avança na trilha da região se o tamanho da expedição superar sua posição atual.',
+    'Mercenário': 'Coringa — pode entrar em qualquer expedição, mas não pode ser líder.',
+  }
+
   const [leaderPos, setLeaderPos] = useState<number | null>(null)
   const [loading, setLoading] = useState(false)
 
@@ -123,7 +139,13 @@ export default function Expedition() {
                 Líder: <span className="text-amber-300 font-semibold">{leaderCard.role ?? leaderCard.function}</span>
                 {leaderCard.region && <> da região <span className="text-amber-300 font-semibold">{leaderCard.region}</span></>}
               </p>
-              <p className="mt-1 text-slate-400 text-xs">
+              {leaderCard.role && LEADER_ABILITIES[leaderCard.role] && (
+                <div className="mt-2 flex items-start gap-2 bg-amber-500/10 border border-amber-500/30 rounded-lg px-3 py-2">
+                  <Crown className="w-4 h-4 text-amber-400 mt-0.5 shrink-0" />
+                  <p className="text-amber-200 text-xs">{LEADER_ABILITIES[leaderCard.role]}</p>
+                </div>
+              )}
+              <p className="mt-2 text-slate-400 text-xs">
                 As outras cartas devem ter o mesmo papel ou a mesma região.
               </p>
             </div>

--- a/frontend/src/app/types.ts
+++ b/frontend/src/app/types.ts
@@ -1,4 +1,4 @@
-export type CardColor = 'red' | 'blue' | 'green' | 'yellow' | 'purple';
+export type CardColor = 'red' | 'blue' | 'green' | 'yellow' | 'purple' | 'orange';
 export type CardFunction = 'excavation' | 'transport' | 'research' | 'funding' | 'artifact' | 'monkey';
 
 export interface GameCard {


### PR DESCRIPTION
- Pontos de expedição agora são contabilizados em tempo real ao jogar, não apenas no fim da temporada
- Oceania recebe cor laranja, resolvendo conflito de cor com América do Norte
- Carta exibe profissão e região no lugar do número
- Tela de expedição mostra o poder especial do líder ao selecioná-lo